### PR TITLE
Fix mouse input on Linux with debug build.

### DIFF
--- a/src/unix/sdl_input.cpp
+++ b/src/unix/sdl_input.cpp
@@ -249,7 +249,6 @@ IN_ActivateMouse
 */
 static void IN_ActivateMouse( void )
 {
-#if !(defined(DEBUG) && defined(__linux__))
 	if (!mouseAvailable || !SDL_WasInit( SDL_INIT_VIDEO ) )
 		return;
 
@@ -276,7 +275,6 @@ static void IN_ActivateMouse( void )
 	}
 
 	mouseActive = qtrue;
-#endif
 }
 
 /*


### PR DESCRIPTION
I don't know why this was here, but it stopped the window from capturing mouse input with a debug build.