### PR TITLE
Fix SV_DumpUser_f so it's usable

### DIFF
--- a/src/server/sv_ccmds.cpp
+++ b/src/server/sv_ccmds.cpp
@@ -923,12 +923,16 @@ static void SV_DumpUser_f( void ) {
 		return;
 	}
 
-	cl = SV_GetPlayerByName();
+	//cl = SV_GetPlayerByName();
+	//don't try to identify by exact player name, but by client number (much easier to input)
+	cl = SV_GetPlayerByNum();
+	
 	if ( !cl ) {
 		return;
 	}
 
 	Com_Printf( "userinfo\n" );
+	Com_Printf("\"%s\"\n", cl->userinfo)	//also print the raw userinfo string in case Info_Print bugs
 	Com_Printf( "--------\n" );
 	Info_Print( cl->userinfo );
 }


### PR DESCRIPTION
SV_GetPlayerByName() is really bad for finding a client.
I suggest making this change to find by client number instead so it's easier to use. Also, since Info_Print bugs sometimes, print the raw string as well.