### PR TITLE
Change back default console font to the original

### DIFF
--- a/CVARS.rst
+++ b/CVARS.rst
@@ -171,7 +171,7 @@ Client-Side
 
 :Name: r_consoleFont
 :Values: "0", "1", "2"
-:Default: "1"
+:Default: "0"
 :Description:
    Font used in console, timer, message input field and other places:
 

--- a/src/renderer/tr_init.cpp
+++ b/src/renderer/tr_init.cpp
@@ -1347,7 +1347,7 @@ Ghoul2 Insert End
 
 	r_screenshotJpegQuality = ri.Cvar_Get("r_screenshotJpegQuality", "95", CVAR_ARCHIVE | CVAR_GLOBAL);
 
-	r_consoleFont = ri.Cvar_Get("r_consoleFont", "1", CVAR_ARCHIVE | CVAR_GLOBAL);
+	r_consoleFont = ri.Cvar_Get("r_consoleFont", "0", CVAR_ARCHIVE | CVAR_GLOBAL);
 	r_consoleFont->modified = qtrue;
 	r_fontSharpness = ri.Cvar_Get("r_fontSharpness", "1", CVAR_ARCHIVE | CVAR_GLOBAL);
 	r_textureLODBias = ri.Cvar_Get("r_textureLODBias", "0", CVAR_ARCHIVE | CVAR_GLOBAL);


### PR DESCRIPTION
This is a new feature so I think the default font should be the original