### PR TITLE
Snaps and rate policies

### DIFF
--- a/CVARS.rst
+++ b/CVARS.rst
@@ -410,6 +410,15 @@ Server-Side
 
 ..
 
+:Name: sv_enforceSnaps
+:Values: "0", "1"
+:Default: "0"
+:Description:
+   Ignore the client preference for "snaps" and try to send a snapshot per
+   server frame (sv_fps) if sv_maxSnaps and the client rate permit it.
+
+..
+
 :Name: sv_floodProtect
 :Values: Integer >= 0
 :Default: "3"
@@ -447,6 +456,42 @@ Server-Side
 :Description:
    Max out-of-bound requests handled per second. Increasing rate
    improves server responsiveness at the cost of higher CPU usage.
+
+..
+
+:Name: sv_maxRate
+:Valid: "0", Integer >= 1000
+:Default: "90000"
+:Description:
+   Maximum rate for each client. The client rate limits the maximum amount of
+   snapshots sent to a client.
+
+..
+
+:Name: sv_maxSnaps
+:Valid: Integer > 0
+:Default: "30"
+:Description:
+   Maximum amount of snapshots each client should receive. This can also be
+   limited by the client rate.
+
+..
+
+:Name: sv_minRate
+:Valid: Integer >= 1000
+:Default: "1000"
+:Description:
+   Minimum rate for each client. The client rate limits the maximum amount of
+   snapshots sent to a client.
+
+..
+
+:Name: sv_minSnaps
+:Valid: Integer > 0
+:Default: "1"
+:Description:
+   Minimum amount of snapshots each client should receive. This can also be
+   limited by the client rate.
 
 ..
 

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -242,11 +242,9 @@ extern	cvar_t	*sv_killserver;
 extern	cvar_t	*sv_mapname;
 extern	cvar_t	*sv_mapChecksum;
 extern	cvar_t	*sv_serverid;
-extern	cvar_t	*sv_snapsMin;
-extern	cvar_t	*sv_snapsMax;
-extern	cvar_t	*sv_snapsPolicy;
-extern	cvar_t	*sv_ratePolicy;
-extern	cvar_t	*sv_clientRate;
+extern	cvar_t	*sv_minSnaps;
+extern	cvar_t	*sv_maxSnaps;
+extern	cvar_t	*sv_enforceSnaps;
 extern	cvar_t	*sv_minRate;
 extern	cvar_t	*sv_maxRate;
 extern	cvar_t	*sv_maxOOBRate;
@@ -333,6 +331,8 @@ void SV_ClientThink (int client, const usercmd_t *cmd);
 
 void SV_WriteDownloadToClient( client_t *cl , msg_t *msg );
 void SV_CloseDownload( client_t *cl );
+
+int SV_ClientRate( client_t *client );
 
 //
 // sv_ccmds.c

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -159,7 +159,6 @@ typedef struct client_s {
 	int				ping;
 	int				rate;				// bytes / second
 	int				snapshotMsec;		// requests a snapshot every snapshotMsec unless rate choked
-	int				wishSnaps;			// requested snapshot/sec rate
 	int				pureAuthentic;
 	netchan_t		netchan;
 	int				oldServerTime;		// client server time before map change
@@ -333,6 +332,8 @@ void SV_WriteDownloadToClient( client_t *cl , msg_t *msg );
 void SV_CloseDownload( client_t *cl );
 
 int SV_ClientRate( client_t *client );
+int SV_ClientSnaps( client_t *client );
+void SV_ClientUpdateSnaps( client_t *client );
 
 //
 // sv_ccmds.c

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -159,6 +159,7 @@ typedef struct client_s {
 	int				ping;
 	int				rate;				// bytes / second
 	int				snapshotMsec;		// requests a snapshot every snapshotMsec unless rate choked
+	int				wishSnaps;			// requested snapshot/sec rate
 	int				pureAuthentic;
 	netchan_t		netchan;
 	int				oldServerTime;		// client server time before map change
@@ -241,6 +242,12 @@ extern	cvar_t	*sv_killserver;
 extern	cvar_t	*sv_mapname;
 extern	cvar_t	*sv_mapChecksum;
 extern	cvar_t	*sv_serverid;
+extern	cvar_t	*sv_snapsMin;
+extern	cvar_t	*sv_snapsMax;
+extern	cvar_t	*sv_snapsPolicy;
+extern	cvar_t	*sv_ratePolicy;
+extern	cvar_t	*sv_clientRate;
+extern	cvar_t	*sv_minRate;
 extern	cvar_t	*sv_maxRate;
 extern	cvar_t	*sv_maxOOBRate;
 extern	cvar_t	*sv_minPing;

--- a/src/server/sv_ccmds.cpp
+++ b/src/server/sv_ccmds.cpp
@@ -637,7 +637,7 @@ static void SV_Status_f( void )
 			svs.time - cl->lastPacketTime,
 			s,
 			cl->netchan.qport,
-			cl->rate
+			SV_ClientRate(cl)
 			);
 	}
 	Com_Printf ("\n");

--- a/src/server/sv_client.cpp
+++ b/src/server/sv_client.cpp
@@ -1640,32 +1640,17 @@ void SV_ExecuteClientMessage( client_t *cl, msg_t *msg ) {
 
 int SV_ClientRate( client_t *client )
 {
-	int rate = client->rate;
+	int minRate = sv_minRate->integer;
+	int maxRate = sv_maxRate->integer;
 
-	if ( sv_maxRate->integer ) {
-		if ( sv_maxRate->integer < 1000 ) {
-			Cvar_Set( "sv_maxRate", "1000" );
-		}
-		if ( sv_maxRate->integer < rate ) {
-			rate = sv_maxRate->integer;
-		}
-	}
-	else if ( 90000 < rate ) { // Special case for sv_maxRate 0: "unlimited" was hardcoded to 90000 in jk2ded
-		rate = 90000;
-	}
+	// Special case for sv_maxRate 0: "unlimited" was hardcoded to 90000 in jk2ded
+	if ( !maxRate ) maxRate = 90000;
 
-	if ( sv_minRate->integer ) {
-		if ( sv_minRate->integer < 1000 ) {
-			Cvar_Set( "sv_minRate", "1000" );
-		}
-		if ( sv_minRate->integer > rate ) {
-			rate = sv_minRate->integer;
-		}
-	}
-	else if ( 1000 > rate ) { // minimum was hardcoded to 1000 in jk2ded
-		rate = 1000;
-	}
+	// Never allow rates below 1000 (was already hardcoded to 1000 in jk2ded)
+	if ( minRate < 1000 ) minRate = 1000;
+	if ( maxRate < 1000 ) maxRate = 1000;
 
-	return rate;
+	// Ensure the rate is within the allowed range
+	return Com_Clampi( minRate, maxRate, client->rate );
 }
 

--- a/src/server/sv_init.cpp
+++ b/src/server/sv_init.cpp
@@ -796,6 +796,12 @@ void SV_Init (void) {
 	sv_privateClients = Cvar_Get ("sv_privateClients", "0", CVAR_SERVERINFO);
 	sv_hostname = Cvar_Get ("sv_hostname", "noname", CVAR_SERVERINFO | CVAR_ARCHIVE );
 	sv_maxclients = Cvar_Get ("sv_maxclients", "8", CVAR_SERVERINFO | CVAR_LATCH);
+	sv_snapsMin = Cvar_Get("sv_snapsMin", "0", CVAR_TEMP); // 1 <=> sv_snapsMax
+	sv_snapsMax = Cvar_Get("sv_snapsMax", "0", CVAR_TEMP); // sv_snapsMin <=> sv_fps
+	sv_snapsPolicy = Cvar_Get("sv_snapsPolicy", "2", CVAR_TEMP); // 0=does nothing, 1=enforces snaps setting to match sv_fps, 2=restricts snaps settings to stay between sv_snapsMin and sv_snapsMax
+	sv_ratePolicy = Cvar_Get( "sv_ratePolicy", "1", CVAR_ARCHIVE ); // "Determines which policy of enforcement is used for client's \"rate\" cvar" );
+	sv_clientRate = Cvar_Get( "sv_clientRate", "90000", CVAR_TEMP );
+	sv_minRate = Cvar_Get("sv_minRate", "0", CVAR_TEMP ); // "Min bandwidth rate allowed on server. Use 0 for unlimited."
 	sv_maxRate = Cvar_Get ("sv_maxRate", "0", CVAR_ARCHIVE | CVAR_SERVERINFO );
 	sv_maxOOBRate = Cvar_Get ("sv_maxOOBRate", "20", CVAR_ARCHIVE | CVAR_GLOBAL );
 	sv_minPing = Cvar_Get ("sv_minPing", "0", CVAR_ARCHIVE | CVAR_SERVERINFO );

--- a/src/server/sv_init.cpp
+++ b/src/server/sv_init.cpp
@@ -796,13 +796,11 @@ void SV_Init (void) {
 	sv_privateClients = Cvar_Get ("sv_privateClients", "0", CVAR_SERVERINFO);
 	sv_hostname = Cvar_Get ("sv_hostname", "noname", CVAR_SERVERINFO | CVAR_ARCHIVE );
 	sv_maxclients = Cvar_Get ("sv_maxclients", "8", CVAR_SERVERINFO | CVAR_LATCH);
-	sv_snapsMin = Cvar_Get("sv_snapsMin", "0", CVAR_TEMP); // 1 <=> sv_snapsMax
-	sv_snapsMax = Cvar_Get("sv_snapsMax", "0", CVAR_TEMP); // sv_snapsMin <=> sv_fps
-	sv_snapsPolicy = Cvar_Get("sv_snapsPolicy", "2", CVAR_TEMP); // 0=does nothing, 1=enforces snaps setting to match sv_fps, 2=restricts snaps settings to stay between sv_snapsMin and sv_snapsMax
-	sv_ratePolicy = Cvar_Get( "sv_ratePolicy", "1", CVAR_ARCHIVE ); // "Determines which policy of enforcement is used for client's \"rate\" cvar" );
-	sv_clientRate = Cvar_Get( "sv_clientRate", "90000", CVAR_TEMP );
-	sv_minRate = Cvar_Get("sv_minRate", "0", CVAR_TEMP ); // "Min bandwidth rate allowed on server. Use 0 for unlimited."
-	sv_maxRate = Cvar_Get ("sv_maxRate", "0", CVAR_ARCHIVE | CVAR_SERVERINFO );
+	sv_minSnaps = Cvar_Get("sv_minSnaps", "1", CVAR_ARCHIVE);                        // jk2ded hardcoded min: 1
+	sv_maxSnaps = Cvar_Get("sv_maxSnaps", "30", CVAR_ARCHIVE);                       // jk2ded hardcoded max: 30
+	sv_enforceSnaps = Cvar_Get("sv_enforceSnaps", "0", CVAR_ARCHIVE);                // 0: users choice (limited by min/max snaps); 1: sv_fps (limited by min/max snaps)	
+	sv_minRate = Cvar_Get("sv_minRate", "1000", CVAR_ARCHIVE | CVAR_SERVERINFO );    // jk2ded hardcoded min: 1000
+	sv_maxRate = Cvar_Get ("sv_maxRate", "90000", CVAR_ARCHIVE | CVAR_SERVERINFO );  // jk2ded hardcoded max: 90000
 	sv_maxOOBRate = Cvar_Get ("sv_maxOOBRate", "20", CVAR_ARCHIVE | CVAR_GLOBAL );
 	sv_minPing = Cvar_Get ("sv_minPing", "0", CVAR_ARCHIVE | CVAR_SERVERINFO );
 	sv_maxPing = Cvar_Get ("sv_maxPing", "0", CVAR_ARCHIVE | CVAR_SERVERINFO );

--- a/src/server/sv_main.cpp
+++ b/src/server/sv_main.cpp
@@ -1078,9 +1078,7 @@ void SV_CheckCvars(void) {
 		sv_enforceSnaps->modificationCount != lastModEnforceSnaps)
 	{
 		client_t *cl;
-		int minSnaps = sv_minSnaps->integer > 0 ? Com_Clampi(1, sv_maxSnaps->integer, sv_minSnaps->integer) : 1; // between 1 and sv_maxSnaps ( 1 <-> 40 )
-		int maxSnaps = sv_maxSnaps->integer > 0 ? MIN(sv_fps->integer, sv_maxSnaps->integer) : sv_fps->integer;  // can't produce more than sv_fps snapshots/sec, but can send less than sv_fps snapshots/sec
-		int i, val;
+		int i;
 
 		lastModFramerate = sv_fps->modificationCount;
 		lastModSnapsMin = sv_minSnaps->modificationCount;
@@ -1088,12 +1086,8 @@ void SV_CheckCvars(void) {
 		lastModEnforceSnaps = sv_enforceSnaps->modificationCount;
 
 		for (i = 0, cl = svs.clients; i < sv_maxclients->integer; i++, cl++) {
-			val = 1000/Com_Clampi(minSnaps, maxSnaps, (sv_enforceSnaps->integer ? sv_fps->integer : cl->wishSnaps) );
-
-			if (val != cl->snapshotMsec) {
-				// Reset last sent snapshot so we avoid desync between server frame time and snapshot send time
-				cl->nextSnapshotTime = -1;
-				cl->snapshotMsec = val;
+			if ( cl->state >= CS_CONNECTED ) {
+				SV_ClientUpdateSnaps( cl );
 			}
 		}
 	}

--- a/src/server/sv_main.cpp
+++ b/src/server/sv_main.cpp
@@ -24,6 +24,12 @@ cvar_t	*sv_killserver;			// menu system can set to 1 to shut server down
 cvar_t	*sv_mapname;
 cvar_t	*sv_mapChecksum;
 cvar_t	*sv_serverid;
+cvar_t	*sv_snapsMin;			// minimum snapshots/sec a client can request, also limited by sv_snapsMax
+cvar_t	*sv_snapsMax;			// maximum snapshots/sec a client can request, also limited by sv_fps
+cvar_t	*sv_snapsPolicy;		// 0-2
+cvar_t	*sv_ratePolicy;			// 1-2
+cvar_t	*sv_clientRate;
+cvar_t	*sv_minRate;
 cvar_t	*sv_maxRate;
 cvar_t	*sv_maxOOBRate;
 cvar_t	*sv_minPing;
@@ -1041,6 +1047,132 @@ qboolean SV_CheckPaused( void ) {
 	return qtrue;
 }
 
+void SV_CheckCvars(void) {
+	static int lastModHostname = -1, lastModFramerate = -1, lastModSnapsMin = -1, lastModSnapsMax = -1;
+	static int lastModSnapsPolicy = -1, lastModRatePolicy = -1, lastModClientRate = -1;
+	static int lastModMaxRate = -1, lastModMinRate = -1;
+	qboolean changed = qfalse;
+
+	if (sv_hostname->modificationCount != lastModHostname) {
+		char hostname[MAX_INFO_STRING];
+		char *c = hostname;
+		lastModHostname = sv_hostname->modificationCount;
+
+		strcpy(hostname, sv_hostname->string);
+		while (*c)
+		{
+			if ((*c == '\\') || (*c == ';') || (*c == '"'))
+			{
+				*c = '.';
+				changed = qtrue;
+			}
+			c++;
+		}
+		if (changed)
+		{
+			Cvar_Set("sv_hostname", hostname);
+		}
+	}
+
+	// check limits on client "rate" values based on server settings
+	if ( sv_clientRate->modificationCount != lastModClientRate ||
+		 sv_minRate->modificationCount != lastModMinRate ||
+		 sv_maxRate->modificationCount != lastModMaxRate ||
+		 sv_ratePolicy->modificationCount != lastModRatePolicy )
+	{
+		sv_clientRate->modificationCount = lastModClientRate;
+		sv_maxRate->modificationCount = lastModMaxRate;
+		sv_minRate->modificationCount = lastModMinRate;
+		sv_ratePolicy->modificationCount = lastModRatePolicy;
+		if (sv_ratePolicy->integer == 1)
+		{
+			// NOTE: what if server sets some dumb sv_clientRate value?
+			client_t *cl = NULL;
+			int i = 0;
+			for (i = 0, cl = svs.clients; i < sv_maxclients->integer; i++, cl++) {
+				// if the client is on the same subnet as the server and we aren't running an
+				// internet public server, assume they don't need a rate choke
+				if (Sys_IsLANAddress(cl->netchan.remoteAddress) && com_dedicated->integer != 2) {
+					cl->rate = 100000;	// lans should not rate limit
+				}
+				else {
+					int val = sv_clientRate->integer;
+					if (val != cl->rate) {
+						cl->rate = val;
+					}
+				}
+			}
+		}
+		else if (sv_ratePolicy->integer == 2)
+		{
+			// NOTE: what if server sets some dumb sv_clientRate value?
+			client_t *cl = NULL;
+			int i = 0;
+			for (i = 0, cl = svs.clients; i < sv_maxclients->integer; i++, cl++) {
+				// if the client is on the same subnet as the server and we aren't running an
+				// internet public server, assume they don't need a rate choke
+				if (Sys_IsLANAddress(cl->netchan.remoteAddress) && com_dedicated->integer != 2) {
+					cl->rate = 100000;	// lans should not rate limit
+				}
+				else {
+					int val = cl->rate;
+					if (!val) {
+						val = sv_maxRate->integer;
+					}
+					val = Com_Clampi( 1000, 90000, val );
+					val = Com_Clampi( sv_minRate->integer, sv_maxRate->integer, val );
+					if (val != cl->rate) {
+						cl->rate = val;
+					}
+				}
+			}
+		}
+	}
+
+	// check limits on client "snaps" value based on server framerate and snapshot rate
+	if (sv_fps->modificationCount != lastModFramerate ||
+		sv_snapsMin->modificationCount != lastModSnapsMin ||
+		sv_snapsMax->modificationCount != lastModSnapsMax ||
+		sv_snapsPolicy->modificationCount != lastModSnapsPolicy)
+	{
+		lastModFramerate = sv_fps->modificationCount;
+		lastModSnapsMin = sv_snapsMin->modificationCount;
+		lastModSnapsMax = sv_snapsMax->modificationCount;
+		lastModSnapsPolicy = sv_snapsPolicy->modificationCount;
+
+		if (sv_snapsPolicy->integer == 1)
+		{
+			client_t *cl = NULL;
+			int i = 0;
+
+			for (i = 0, cl = svs.clients; i < sv_maxclients->integer; i++, cl++) {
+				int val = 1000 / sv_fps->integer;
+				if (val != cl->snapshotMsec) {
+					// Reset last sent snapshot so we avoid desync between server frame time and snapshot send time
+					cl->nextSnapshotTime = -1;
+					cl->snapshotMsec = val;
+				}
+			}
+		}
+		else if (sv_snapsPolicy->integer == 2)
+		{
+			client_t *cl = NULL;
+			int i = 0;
+			int minSnaps = sv_snapsMin->integer > 0 ? Com_Clampi(1, sv_snapsMax->integer, sv_snapsMin->integer) : 1; // between 1 and sv_snapsMax ( 1 <-> 40 )
+			int maxSnaps = sv_snapsMax->integer > 0 ? MIN(sv_fps->integer, sv_snapsMax->integer) : sv_fps->integer; // can't produce more than sv_fps snapshots/sec, but can send less than sv_fps snapshots/sec
+
+			for (i = 0, cl = svs.clients; i < sv_maxclients->integer; i++, cl++) {
+				int val = 1000 / Com_Clampi(minSnaps, maxSnaps, cl->wishSnaps);
+				if (val != cl->snapshotMsec) {
+					// Reset last sent snapshot so we avoid desync between server frame time and snapshot send time
+					cl->nextSnapshotTime = -1;
+					cl->snapshotMsec = val;
+				}
+			}
+		}
+	}
+}
+
 /*
 ==================
 SV_FrameMsec
@@ -1203,6 +1335,8 @@ void SV_Frame( int msec ) {
 
 	// send messages back to the clients
 	SV_SendClientMessages();
+
+	SV_CheckCvars();
 
 	// send a heartbeat to the master if needed
 	SV_MasterHeartbeat();

--- a/src/server/sv_snapshot.cpp
+++ b/src/server/sv_snapshot.cpp
@@ -546,29 +546,12 @@ to take to clear, based on the current rate
 */
 #define	HEADER_RATE_BYTES	48		// include our header, IP header, and some overhead
 static int SV_RateMsec( client_t *client, int messageSize ) {
-	int		rate;
+	int		rate = SV_ClientRate( client );
 	int		rateMsec;
 
 	// individual messages will never be larger than fragment size
 	if ( messageSize > 1500 ) {
 		messageSize = 1500;
-	}
-	rate = client->rate;
-	if ( sv_maxRate->integer ) {
-		if ( sv_maxRate->integer < 1000 ) {
-			Cvar_Set( "sv_MaxRate", "1000" );
-		}
-		if ( sv_maxRate->integer < rate ) {
-			rate = sv_maxRate->integer;
-		}
-	}
-	if ( sv_minRate->integer ) {
-		if ( sv_minRate->integer < 1000 ) {
-			Cvar_Set( "sv_minRate", "1000" );
-		}
-		if ( sv_minRate->integer > rate ) {
-			rate = sv_minRate->integer;
-		}
 	}
 	rateMsec = ( messageSize + HEADER_RATE_BYTES ) * 1000 / rate;
 

--- a/src/server/sv_snapshot.cpp
+++ b/src/server/sv_snapshot.cpp
@@ -562,6 +562,14 @@ static int SV_RateMsec( client_t *client, int messageSize ) {
 			rate = sv_maxRate->integer;
 		}
 	}
+	if ( sv_minRate->integer ) {
+		if ( sv_minRate->integer < 1000 ) {
+			Cvar_Set( "sv_minRate", "1000" );
+		}
+		if ( sv_minRate->integer > rate ) {
+			rate = sv_minRate->integer;
+		}
+	}
 	rateMsec = ( messageSize + HEADER_RATE_BYTES ) * 1000 / rate;
 
 	return rateMsec;


### PR DESCRIPTION
As mentioned in #128:
> As the jk2 default value for `rate` is rather low and as some servers run on higher frame rates than the default `snaps` server admins have asked for an option to override the "rate" and "snaps" values specified in the userinfo of clients. Unchanged default values are often the cause of small lags perceived by clients who didn't raise their values. Servers running their own modified engine versions to use higher rates than specified by the client userinfo have been referred to as running smoother than others.
> 
> For jk2mp the rate defaults to 4000. However on crowded servers with many entities the lagometer (`cg_lagometer 1`) occasionally indicates delayed snapshots due to rate limitting even at a rate of 25000, so some servers recently increased their upper rate limits from 25000 to 90000. However many clients are not aware of this and it's a common suggestion for new players to increase their rate value from 4000 to 25000. So the values 4000 and 25000 are still very common among players today.
> 
> Due to the above it has been considered to add a new cvar called `sv_minRate`, to be used in combination with the existing `sv_maxRate` cvar to limit client rates within a chosen range. Similar to that the cvars `sv_minSnaps` and `sv_maxSnaps` have been proposed, as well as `sv_snapsPolicy` to automatically adjust the amount of sent snapshots to the server frame rate (`sv_fps`).

