### PR TITLE
SDL High DPI support for wayland/cocoa (*nix/macos)

### DIFF
--- a/CVARS.rst
+++ b/CVARS.rst
@@ -267,6 +267,15 @@ Client-Side
 
 ..
 
+:Name: r_highdpi
+:Values: "0", "1"
+:Default: "0"
+:Description:
+   Enable / Disable high DPI rendering when desktop scaling is
+   enabled. Not very well supported, results may vary.
+
+..
+
 :Name: r_saberGlow
 :Values: "0", "1"
 :Default: "1"

--- a/CVARS.rst
+++ b/CVARS.rst
@@ -269,10 +269,10 @@ Client-Side
 
 :Name: r_highdpi
 :Values: "0", "1"
-:Default: "0"
+:Default: "1"
 :Description:
    Enable / Disable high DPI rendering when desktop scaling is
-   enabled. Not very well supported, results may vary.
+   enabled.
 
 ..
 

--- a/res/mv.plist
+++ b/res/mv.plist
@@ -30,5 +30,7 @@
 	<string>${MACOSX_BUNDLE_COPYRIGHT}</string>
 	<key>CFBundleDisplayName</key>
 	<string>${MACOSX_BUNDLE_DISPLAY_NAME}</string>
+	<key>NSHighResolutionCapable</key>
+	<true/>
 </dict>
 </plist>

--- a/src/cgame/tr_types.h
+++ b/src/cgame/tr_types.h
@@ -349,13 +349,12 @@ typedef struct {
 	qboolean				textureLODBiasAvailable;
 	qboolean				clampToEdgeAvailable;
 
-	int						vidWidth, vidHeight;
+	int						winWidth, winHeight;	// window size
 	// aspect is the screen's physical width / height, which may be different
 	// than scrWidth / scrHeight if the pixels are non-square
 	// normal screens should be 4/3, but wide aspect monitors may be 16/9
 	float					windowAspect;
 
-	float					displayScale;
 	int						displayFrequency;
 
 	// synonymous with "does rendering consume the entire screen?", therefore
@@ -367,8 +366,14 @@ typedef struct {
 
 	// gamma correction
 	qboolean				deviceSupportsPostprocessingGamma;
-} glconfig_t;
 
+	//
+	// following variables can change every frame!
+	//
+
+	int						vidWidth, vidHeight;	// OpenGL drawable size
+	float					displayScale;
+} glconfig_t;
 
 #if !defined _WIN32
 

--- a/src/client/cl_avi.cpp
+++ b/src/client/cl_avi.cpp
@@ -582,6 +582,11 @@ void CL_TakeVideoFrame( void )
 	if( !afd.fileOpen )
 		return;
 
+	if ( afd.width != cls.glconfig.vidWidth || afd.height != cls.glconfig.vidHeight ) {
+		CL_CloseAVI();
+		Com_Error( ERR_DROP, "ERROR: Renderer output dimensions changed while capturing AVI video" );
+	}
+
 	if ( afd.motionJpeg ) {
 		size = re.CaptureFrameJPEG( afd.frameBuffer, afd.frameBufferSize, cl_aviMotionJpegQuality->integer );
 	} else {

--- a/src/client/cl_main.cpp
+++ b/src/client/cl_main.cpp
@@ -2621,6 +2621,18 @@ void CL_InitRenderer( void ) {
 }
 
 /*
+============
+CL_UpdateGLConfig
+============
+*/
+void CL_UpdateRefConfig( void ) {
+	re.UpdateGLConfig( &cls.glconfig );
+
+	cls.xadjust = (float) SCREEN_WIDTH / cls.glconfig.vidWidth;
+	cls.yadjust = (float) SCREEN_HEIGHT / cls.glconfig.vidHeight;
+}
+
+/*
 ============================
 CL_StartHunkUsers
 
@@ -4036,8 +4048,10 @@ void CL_GetVMGLConfig(vmglconfig_t *vmglconfig) {
 	vmglconfig->textureFilterAnisotropicAvailable = cls.glconfig.textureFilterAnisotropicMax == 0.0f ? qfalse : qtrue;
 	vmglconfig->clampToEdgeAvailable = cls.glconfig.clampToEdgeAvailable;
 
-	vmglconfig->vidWidth = cls.glconfig.vidWidth;
-	vmglconfig->vidHeight = cls.glconfig.vidHeight;
+	// pass window size instead of drawable size because original
+	// modules don't support changing vidWidth/vidHeight
+	vmglconfig->vidWidth = cls.glconfig.winWidth;
+	vmglconfig->vidHeight = cls.glconfig.winHeight;
 	vmglconfig->windowAspect = cls.glconfig.windowAspect;
 	vmglconfig->displayFrequency = cls.glconfig.displayFrequency;
 	vmglconfig->isFullscreen = cls.glconfig.isFullscreen;

--- a/src/client/cl_scrn.cpp
+++ b/src/client/cl_scrn.cpp
@@ -510,6 +510,8 @@ void SCR_UpdateScreen( void ) {
 	}
 	recursive = 1;
 
+	CL_UpdateRefConfig( );
+
 	// if running in stereo, we need to draw the frame twice
 	if ( cls.glconfig.stereoEnabled ) {
 		SCR_DrawScreenField( STEREO_LEFT );

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -495,6 +495,7 @@ int CL_GetPingQueueCount( void );
 
 void CL_ShutdownRef( void );
 void CL_InitRef( void );
+void CL_UpdateRefConfig( void );
 
 int CL_ServerStatus( const char *serverAddress, char *serverStatusString, int maxLen );
 

--- a/src/renderer/tr_image.cpp
+++ b/src/renderer/tr_image.cpp
@@ -2493,6 +2493,54 @@ static void R_CreateDefaultImage( void ) {
 	tr.defaultImage = R_CreateImage("*default", (byte *)data, DEFAULT_SIZE, DEFAULT_SIZE, qtrue, qfalse, qfalse, GL_REPEAT );
 }
 
+static void R_BindGlowImages( void ) {
+	// Update dynamic glow textures when vidWidth/vidHeight changes
+
+	qglDisable( GL_TEXTURE_2D );
+	qglEnable( GL_TEXTURE_RECTANGLE_ARB );
+
+	if (tr.screenGlow) {
+		// Create the scene glow image. - AReis
+		qglBindTexture( GL_TEXTURE_RECTANGLE_ARB, tr.screenGlow );
+		qglTexImage2D( GL_TEXTURE_RECTANGLE_ARB, 0, GL_RGBA16, glConfig.vidWidth, glConfig.vidHeight, 0, GL_RGB, GL_FLOAT, 0 );
+		qglTexParameteri( GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_MIN_FILTER, GL_LINEAR );
+		qglTexParameteri( GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_MAG_FILTER, GL_LINEAR );
+		qglTexParameteri( GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_WRAP_S, GL_CLAMP );
+		qglTexParameteri( GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_WRAP_T, GL_CLAMP );
+	}
+	if (tr.sceneImage) {
+		// Create the scene image. - AReis
+		qglBindTexture( GL_TEXTURE_RECTANGLE_ARB, tr.sceneImage );
+		qglTexImage2D( GL_TEXTURE_RECTANGLE_ARB, 0, GL_RGBA16, glConfig.vidWidth, glConfig.vidHeight, 0, GL_RGB, GL_FLOAT, 0 );
+		qglTexParameteri( GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_MIN_FILTER, GL_LINEAR );
+		qglTexParameteri( GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_MAG_FILTER, GL_LINEAR );
+		qglTexParameteri( GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_WRAP_S, GL_CLAMP );
+		qglTexParameteri( GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_WRAP_T, GL_CLAMP );
+	}
+
+	if ( r_DynamicGlowWidth->integer > glConfig.vidWidth  )
+	{
+		r_DynamicGlowWidth->integer = glConfig.vidWidth;
+	}
+	if ( r_DynamicGlowHeight->integer > glConfig.vidHeight  )
+	{
+		r_DynamicGlowHeight->integer = glConfig.vidHeight;
+	}
+
+	if (tr.blurImage) {
+		// Create the minimized scene blur image.
+		qglBindTexture( GL_TEXTURE_RECTANGLE_ARB, tr.blurImage );
+		qglTexImage2D( GL_TEXTURE_RECTANGLE_ARB, 0, GL_RGBA16, r_DynamicGlowWidth->integer, r_DynamicGlowHeight->integer, 0, GL_RGB, GL_FLOAT, 0 );
+		qglTexParameteri( GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_MIN_FILTER, GL_LINEAR );
+		qglTexParameteri( GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_MAG_FILTER, GL_LINEAR );
+		qglTexParameteri( GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_WRAP_S, GL_CLAMP );
+		qglTexParameteri( GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_WRAP_T, GL_CLAMP );
+	}
+
+	qglDisable( GL_TEXTURE_RECTANGLE_ARB );
+	qglEnable( GL_TEXTURE_2D );
+}
+
 /*
 ==================
 R_CreateBuiltinImages
@@ -2508,44 +2556,11 @@ void R_CreateBuiltinImages( void ) {
 	Com_Memset( data, 255, sizeof( data ) );
 	tr.whiteImage = R_CreateImage("*white", (byte *)data, 8, 8, qfalse, qfalse, qfalse, GL_REPEAT );
 
-	// Create the scene glow image. - AReis
 	tr.screenGlow = 1024 + giTextureBindNum++;
-	qglDisable( GL_TEXTURE_2D );
-	qglEnable( GL_TEXTURE_RECTANGLE_ARB );
-	qglBindTexture( GL_TEXTURE_RECTANGLE_ARB, tr.screenGlow );
-	qglTexImage2D( GL_TEXTURE_RECTANGLE_ARB, 0, GL_RGBA16, glConfig.vidWidth, glConfig.vidHeight, 0, GL_RGB, GL_FLOAT, 0 );
-	qglTexParameteri( GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_MIN_FILTER, GL_LINEAR );
-	qglTexParameteri( GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_MAG_FILTER, GL_LINEAR );
-	qglTexParameteri( GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_WRAP_S, GL_CLAMP );
-	qglTexParameteri( GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_WRAP_T, GL_CLAMP );
-
-	// Create the scene image. - AReis
 	tr.sceneImage = 1024 + giTextureBindNum++;
-	qglBindTexture( GL_TEXTURE_RECTANGLE_ARB, tr.sceneImage );
-	qglTexImage2D( GL_TEXTURE_RECTANGLE_ARB, 0, GL_RGBA16, glConfig.vidWidth, glConfig.vidHeight, 0, GL_RGB, GL_FLOAT, 0 );
-	qglTexParameteri( GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_MIN_FILTER, GL_LINEAR );
-	qglTexParameteri( GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_MAG_FILTER, GL_LINEAR );
-	qglTexParameteri( GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_WRAP_S, GL_CLAMP );
-	qglTexParameteri( GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_WRAP_T, GL_CLAMP );
-
-	// Create the minimized scene blur image.
-	if ( r_DynamicGlowWidth->integer > glConfig.vidWidth  )
-	{
-		r_DynamicGlowWidth->integer = glConfig.vidWidth;
-	}
-	if ( r_DynamicGlowHeight->integer > glConfig.vidHeight  )
-	{
-		r_DynamicGlowHeight->integer = glConfig.vidHeight;
-	}
 	tr.blurImage = 1024 + giTextureBindNum++;
-	qglBindTexture( GL_TEXTURE_RECTANGLE_ARB, tr.blurImage );
-	qglTexImage2D( GL_TEXTURE_RECTANGLE_ARB, 0, GL_RGBA16, r_DynamicGlowWidth->integer, r_DynamicGlowHeight->integer, 0, GL_RGB, GL_FLOAT, 0 );
-	qglTexParameteri( GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_MIN_FILTER, GL_LINEAR );
-	qglTexParameteri( GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_MAG_FILTER, GL_LINEAR );
-	qglTexParameteri( GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_WRAP_S, GL_CLAMP );
-	qglTexParameteri( GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_WRAP_T, GL_CLAMP );
-	qglDisable( GL_TEXTURE_RECTANGLE_ARB );
-	qglEnable( GL_TEXTURE_2D );
+
+	R_BindGlowImages( );
 
 	// with overbright bits active, we need an image which is some fraction of full color,
 	// for default lightmaps, etc
@@ -2578,6 +2593,16 @@ void R_CreateBuiltinImages( void ) {
 	R_CreateFogImage();
 }
 
+/*
+===============
+R_UpdateImages
+
+Update images when renderer size changes
+===============
+*/
+void R_UpdateImages( void ) {
+	R_BindGlowImages();
+}
 
 /*
 ===============

--- a/src/renderer/tr_init.cpp
+++ b/src/renderer/tr_init.cpp
@@ -953,7 +953,8 @@ void GfxInfo_f( void )
 	ri.Printf( PRINT_ALL, "GL_MAX_TEXTURE_SIZE: %d\n", glConfig.maxTextureSize );
 	ri.Printf( PRINT_ALL, "GL_MAX_ACTIVE_TEXTURES_ARB: %d\n", glConfig.maxActiveTextures );
 	ri.Printf( PRINT_ALL, "\nPIXELFORMAT: color(%d-bits) Z(%d-bit) stencil(%d-bits)\n", glConfig.colorBits, glConfig.depthBits, glConfig.stencilBits );
-	ri.Printf( PRINT_ALL, "MODE: %d, %d x %d %s hz:", r_mode->integer, glConfig.vidWidth, glConfig.vidHeight, fsstrings[r_fullscreen->integer == 1] );
+	ri.Printf( PRINT_ALL, "MODE: %d, %d x %d %s hz:", r_mode->integer, glConfig.winWidth, glConfig.winHeight, fsstrings[r_fullscreen->integer == 1] );
+
 	if ( glConfig.displayFrequency )
 	{
 		ri.Printf( PRINT_ALL, "%d\n", glConfig.displayFrequency );
@@ -963,7 +964,8 @@ void GfxInfo_f( void )
 		ri.Printf( PRINT_ALL, "N/A\n" );
 	}
 
-	ri.Printf(PRINT_ALL, "Display Scale: %d%%\n", (int)glConfig.displayScale * 100);
+	ri.Printf( PRINT_ALL, "renderer size: %d x %d\n", glConfig.vidWidth, glConfig.vidHeight );
+	ri.Printf( PRINT_ALL, "display scale: %d%%\n", (int)roundf(glConfig.displayScale * 100.0f));
 
 	// gamma correction
 	if (r_gammamethod->integer == GAMMA_POSTPROCESSING) {
@@ -1448,6 +1450,14 @@ void RE_SetLightStyle(int style, int color)
 	memcpy(styleColors[style], &color, 4);
 }
 
+void RE_UpdateGLConfig( glconfig_t *glconfigOut ) {
+	WIN_UpdateGLConfig( &glConfig );
+
+	glconfigOut->vidWidth = glConfig.vidWidth;
+	glconfigOut->vidHeight = glConfig.vidHeight;
+	glconfigOut->displayScale = glConfig.displayScale;
+}
+
 #endif //!DEDICATED
 /*
 @@@@@@@@@@@@@@@@@@@@@
@@ -1481,6 +1491,7 @@ refexport_t *GetRefAPI ( int apiVersion, refimport_t *rimp ) {
 	re.SetWorldVisData = RE_SetWorldVisData;
 	re.EndRegistration = RE_EndRegistration;
 
+	re.UpdateGLConfig = RE_UpdateGLConfig;
 	re.BeginFrame = RE_BeginFrame;
 	re.EndFrame = RE_EndFrame;
 	re.SwapBuffers = RE_SwapBuffers;

--- a/src/renderer/tr_init.cpp
+++ b/src/renderer/tr_init.cpp
@@ -1451,7 +1451,14 @@ void RE_SetLightStyle(int style, int color)
 }
 
 void RE_UpdateGLConfig( glconfig_t *glconfigOut ) {
+	int		oldWidth = glConfig.vidWidth;
+	int		oldHeight = glConfig.vidHeight;
+
 	WIN_UpdateGLConfig( &glConfig );
+
+	if (oldWidth != glConfig.vidWidth || oldHeight != glConfig.vidHeight) {
+		R_UpdateImages();
+	}
 
 	glconfigOut->vidWidth = glConfig.vidWidth;
 	glconfigOut->vidHeight = glConfig.vidHeight;

--- a/src/renderer/tr_local.h
+++ b/src/renderer/tr_local.h
@@ -1432,6 +1432,7 @@ void	R_ScreenShot_f( void );
 void	R_InitFogTable( void );
 float	R_FogFactor( float s, float t );
 void	R_InitImages( void );
+void	R_UpdateImages( void );
 void	R_DeleteTextures( void );
 float	R_SumOfUsedImages( qboolean bUseFormat );
 void	R_InitSkins( void );

--- a/src/renderer/tr_public.h
+++ b/src/renderer/tr_public.h
@@ -61,6 +61,7 @@ typedef struct {
 	void	(*DrawStretchRaw) (int x, int y, int w, int h, int cols, int rows, const byte *data, int client, qboolean dirty);
 	void	(*UploadCinematic) (int cols, int rows, const byte *data, int client, qboolean dirty);
 
+	void	(*UpdateGLConfig)( glconfig_t *glconfigOut );
 	void	(*BeginFrame)( stereoFrame_t stereoFrame, qboolean skipBackend );
 	void	(*EndFrame)( void );
 

--- a/src/renderer/tr_scene.cpp
+++ b/src/renderer/tr_scene.cpp
@@ -374,6 +374,7 @@ to handle mirrors,
 void RE_RenderScene( const refdef_t *fd ) {
 	viewParms_t		parms;
 	int				startTime;
+	float			xscale, yscale;
 	static	int		lastTime = 0;
 
 	if ( !tr.registered ) {
@@ -393,10 +394,15 @@ void RE_RenderScene( const refdef_t *fd ) {
 
 	Com_Memcpy( tr.refdef.text, fd->text, sizeof( tr.refdef.text ) );
 
-	tr.refdef.x = fd->x;
-	tr.refdef.y = fd->y;
-	tr.refdef.width = fd->width;
-	tr.refdef.height = fd->height;
+	// with fractional scale, aspect ratio and positioning may be
+	// slightly off because of rounding. It is possible to restore it
+	// by adjusting projection matrix.
+	xscale = (float)glConfig.vidWidth / glConfig.winWidth;
+	yscale = (float)glConfig.vidHeight / glConfig.winHeight;
+	tr.refdef.x = (int)roundf(fd->x * xscale);
+	tr.refdef.y = (int)roundf(fd->y * yscale);
+	tr.refdef.width = (int)roundf(fd->width * xscale);
+	tr.refdef.height = (int)roundf(fd->height * yscale);
 	tr.refdef.fov_x = fd->fov_x;
 	tr.refdef.fov_y = fd->fov_y;
 

--- a/src/sdl/sdl_input.cpp
+++ b/src/sdl/sdl_input.cpp
@@ -294,9 +294,9 @@ static void IN_ActivateMouse( void )
 	}
 
 	// in_nograb makes no sense in fullscreen mode
-	if( !(SDL_GetWindowFlags( SDL_window ) & SDL_WINDOW_FULLSCREEN) )
+	if( in_nograb->modified || !mouseActive )
 	{
-		if( in_nograb->modified || !mouseActive )
+		if( !(SDL_GetWindowFlags( SDL_window ) & SDL_WINDOW_FULLSCREEN) )
 		{
 			if( in_nograb->integer )
 			{
@@ -308,9 +308,9 @@ static void IN_ActivateMouse( void )
 				SDL_SetRelativeMouseMode( SDL_TRUE );
 				SDL_SetWindowGrab( SDL_window, SDL_TRUE );
 			}
-
-			in_nograb->modified = qfalse;
 		}
+
+		in_nograb->modified = qfalse;
 	}
 
 	mouseActive = qtrue;

--- a/src/sdl/sdl_input.cpp
+++ b/src/sdl/sdl_input.cpp
@@ -343,7 +343,7 @@ static void IN_DeactivateMouse( void )
 
 		// Don't warp the mouse unless the cursor is within the window
 		if( SDL_GetWindowFlags( SDL_window ) & SDL_WINDOW_MOUSE_FOCUS )
-			SDL_WarpMouseInWindow( SDL_window, cls.glconfig.vidWidth / 2, cls.glconfig.vidHeight / 2 );
+			SDL_WarpMouseInWindow( SDL_window, cls.glconfig.winWidth / 2, cls.glconfig.winHeight / 2 );
 
 		mouseActive = qfalse;
 	}

--- a/src/sdl/sdl_window.cpp
+++ b/src/sdl/sdl_window.cpp
@@ -881,6 +881,7 @@ static rserr_t GLimp_SetMode(glconfig_t *glConfig, const windowDesc_t *windowDes
 	Com_Printf("...renderer size: %d %d\n", glConfig->vidWidth, glConfig->vidHeight);
 
 	glConfig->displayScale = GLimp_GetDisplayScale(display);
+	glConfig->displayScale *= glConfig->vidHeight / winHeight;
 
 	SDL_FreeSurface(icon);
 

--- a/src/sdl/sdl_window.cpp
+++ b/src/sdl/sdl_window.cpp
@@ -34,6 +34,7 @@ static cvar_t	*r_stereo;
 cvar_t			*r_mode;
 cvar_t			*r_displayRefresh;
 static cvar_t	*r_savedWindows;
+static cvar_t	*r_highdpi;
 
 // Window surface cvars
 static cvar_t	*r_stencilbits;
@@ -542,7 +543,7 @@ static rserr_t GLimp_SetMode(glconfig_t *glConfig, const windowDesc_t *windowDes
 	int samples;
 	int i = 0;
 	SDL_Surface *icon = NULL;
-	Uint32 flags = SDL_WINDOW_SHOWN | SDL_WINDOW_ALLOW_HIGHDPI;
+	Uint32 flags = SDL_WINDOW_SHOWN;
 	SDL_DisplayMode desktopMode;
 	int display = 0;
 	int x = SDL_WINDOWPOS_CENTERED, y = SDL_WINDOWPOS_CENTERED;
@@ -552,6 +553,11 @@ static rserr_t GLimp_SetMode(glconfig_t *glConfig, const windowDesc_t *windowDes
 	if ( windowDesc->api == GRAPHICS_API_OPENGL )
 	{
 		flags |= SDL_WINDOW_OPENGL;
+	}
+
+	if ( r_highdpi->integer )
+	{
+		flags |= SDL_WINDOW_ALLOW_HIGHDPI;
 	}
 
 	Com_Printf( "Initializing display\n");
@@ -975,6 +981,7 @@ window_t WIN_Init( const windowDesc_t *windowDesc, glconfig_t *glConfig )
 	r_mode				= Cvar_Get( "r_mode",				"-2",		CVAR_ARCHIVE | CVAR_GLOBAL | CVAR_LATCH );
 	r_displayRefresh	= Cvar_Get( "r_displayRefresh",		"0",		CVAR_LATCH );
 	r_savedWindows		= Cvar_Get( "r_savedWindows",		" ",		CVAR_ARCHIVE | CVAR_GLOBAL | CVAR_ROM );
+	r_highdpi			= Cvar_Get( "r_highdpi",			"0",		CVAR_ARCHIVE | CVAR_GLOBAL | CVAR_LATCH );
 
 	// Window render surface cvars
 	r_stencilbits		= Cvar_Get( "r_stencilbits",		"8",		CVAR_ARCHIVE | CVAR_GLOBAL | CVAR_LATCH );

--- a/src/sdl/sdl_window.cpp
+++ b/src/sdl/sdl_window.cpp
@@ -1008,7 +1008,7 @@ window_t WIN_Init( const windowDesc_t *windowDesc, glconfig_t *glConfig )
 	r_mode				= Cvar_Get( "r_mode",				"-2",		CVAR_ARCHIVE | CVAR_GLOBAL | CVAR_LATCH );
 	r_displayRefresh	= Cvar_Get( "r_displayRefresh",		"0",		CVAR_LATCH );
 	r_savedWindows		= Cvar_Get( "r_savedWindows",		" ",		CVAR_ARCHIVE | CVAR_GLOBAL | CVAR_ROM );
-	r_highdpi			= Cvar_Get( "r_highdpi",			"0",		CVAR_ARCHIVE | CVAR_GLOBAL | CVAR_LATCH );
+	r_highdpi			= Cvar_Get( "r_highdpi",			"1",		CVAR_ARCHIVE | CVAR_GLOBAL | CVAR_LATCH );
 
 	// Window render surface cvars
 	r_stencilbits		= Cvar_Get( "r_stencilbits",		"8",		CVAR_ARCHIVE | CVAR_GLOBAL | CVAR_LATCH );

--- a/src/sys/sys_public.h
+++ b/src/sys/sys_public.h
@@ -190,6 +190,7 @@ typedef enum {
 window_t	WIN_Init( const windowDesc_t *desc, glconfig_t *glConfig );
 void		WIN_InitGammaMethod(glconfig_t *glConfig);
 void		WIN_Present( window_t *window );
+void		WIN_UpdateGLConfig( glconfig_t *glConfig );
 void		WIN_SetGamma( glconfig_t *glConfig, byte red[256], byte green[256], byte blue[256] );
 void		WIN_SetTaskbarState(tbstate_t state, uint64_t current, uint64_t total);
 void		WIN_Shutdown( void );


### PR DESCRIPTION
SDL window's High DPI flags adds support for modern desktop compositors that implement fractional desktop scaling by means of "virtual desktop resolution" that may be different than opengl context resolution.

Using desktop scaling is the best method for ui scaling in jk2mv (console text). Previous method of using display DPI is worse because it doesn't take into account distance from which user is looking at the monitor or personal preferences.

Moreover these new desktop compositors will provide virtual desktop resolution as real resolution for legacy applications and stretch the image by desktop scaling factor, resulting in blurry picture. This is what happens with jk2mv on macos/wayland currently - on a 4k display with desktop scaling 200% jk2mv is rendered at 1080p and stretched to fit the display.

There is only one more thing that still doesn't work before it can be merged, afaik.
Fullscreen window with non-native resolution doesn't work properly. It maybe be due to lack of support in SDL for this case, or maybe we are setting window display resolution wrong.

Because of this, the pull request is not ready to merge. I'm writing all this down in case I forget about it and/or someone wants to finish it in the future. Or perhaps SDL implementation becomes better in new release and it starts working.

SDL's Wayland videodriver doesn't seem to implement high dpi window with opengl context correctly in latest version so it's disabled for now (it has more problems like missing window decorations anyway, so it's rather experimental for now)