### PR TITLE
Add support for loading JKA assets.

### DIFF
--- a/CVARS.rst
+++ b/CVARS.rst
@@ -47,7 +47,7 @@ New and Modified Cvars
 
 ..
 
-:Name: fs_assetsPathJKA
+:Name: fs_assetspathjka
 :Values: Foldername
 :Default: "" (Not set on portable); autodetected for non-portable
 :Description:
@@ -55,11 +55,11 @@ New and Modified Cvars
 
 ..
 
-:Name: fs_loadJKA
+:Name: fs_loadjka
 :Values: "0", "1"
 :Default: "1"
 :Description:
-   Enables loading of JKA assets when fs_assetsPathJKA point to a valid JKA
+   Enables loading of JKA assets when fs_assetspathjka point to a valid JKA
    folder.
 
 -----------

--- a/CVARS.rst
+++ b/CVARS.rst
@@ -55,12 +55,12 @@ New and Modified Cvars
 
 ..
 
-:Name: fs_noJKA
+:Name: fs_loadJKA
 :Values: "0", "1"
-:Default: "0"
+:Default: "1"
 :Description:
-   Disables loading of JKA assets even when fs_assetsPathJKA point to a valid
-   JKA folder.
+   Enables loading of JKA assets when fs_assetsPathJKA point to a valid JKA
+   folder.
 
 -----------
 Client-Side

--- a/CVARS.rst
+++ b/CVARS.rst
@@ -45,6 +45,23 @@ New and Modified Cvars
    | ``fs_game cvar``
    | ``fs_forcegame cvar``
 
+..
+
+:Name: fs_assetsPathJKA
+:Values: Foldername
+:Default: "" (Not set on portable); autodetected for non-portable
+:Description:
+   Sets the path to load JKA assets from.
+
+..
+
+:Name: fs_noJKA
+:Values: "0", "1"
+:Default: "0"
+:Description:
+   Disables loading of JKA assets even when fs_assetsPathJKA point to a valid
+   JKA folder.
+
 -----------
 Client-Side
 -----------

--- a/CVARS.rst
+++ b/CVARS.rst
@@ -55,6 +55,16 @@ New and Modified Cvars
 
 ..
 
+:Name: fs_basejka
+:Values: Foldername
+:Default: "basejka" (if fs_assetspathjka is empty); "base" (if fs_assetspathjka is set)
+:Description:
+   Name of the folder containing the JKA assets within fs_assetspathjka. If
+   fs_assetspathjka is not set the game tries to load assets from the specified
+   folder in fs_basepath and fs_homepath.
+
+..
+
 :Name: fs_loadjka
 :Values: "0", "1"
 :Default: "1"

--- a/src/client/cl_main.cpp
+++ b/src/client/cl_main.cpp
@@ -2701,6 +2701,7 @@ void CL_InitRef( void ) {
 	ri.Hunk_FreeTempMemory = Hunk_FreeTempMemory;
 	ri.CM_DrawDebugSurface = CM_DrawDebugSurface;
 	ri.FS_ReadFile = FS_ReadFile;
+	ri.FS_ReadFileSkipJKA = FS_ReadFileSkipJKA;
 	ri.FS_FreeFile = FS_FreeFile;
 	ri.FS_WriteFile = FS_WriteFile;
 	ri.FS_FreeFileList = FS_FreeFileList;

--- a/src/qcommon/files.cpp
+++ b/src/qcommon/files.cpp
@@ -3351,7 +3351,7 @@ static void FS_Startup( const char *gameName ) {
 	}
 
 	// Try to load JKA assets if a path has been specified
-	if (fs_assetspathjka->string[0] && !fs_loadjka->integer) {
+	if (fs_assetspathjka->string[0] && fs_loadjka->integer) {
 		FS_AddAssetsDirectoryJKA(fs_assetspathjka->string, BASEGAME);
 	}
 

--- a/src/qcommon/files.cpp
+++ b/src/qcommon/files.cpp
@@ -2093,14 +2093,16 @@ static pack_t *FS_LoadZipFile( char *zipfile, const char *basename, qboolean ass
 	}
 
 	// assets are hardcoded
-	if (!Q_stricmp(pack->pakBasename, "assets0")) {
-		pack->gvc = PACKGVC_1_02 | PACKGVC_1_03 | PACKGVC_1_04;
-	} else if (!Q_stricmp(pack->pakBasename, "assets1")) {
-		pack->gvc = PACKGVC_1_02 | PACKGVC_1_03 | PACKGVC_1_04;
-	} else if (!Q_stricmp(pack->pakBasename, "assets2")) {
-		pack->gvc = PACKGVC_1_03 | PACKGVC_1_04;
-	} else if (!Q_stricmp(pack->pakBasename, "assets5")) {
-		pack->gvc = PACKGVC_1_04;
+	if ( !assetsJKA ) {
+		if (!Q_stricmp(pack->pakBasename, "assets0")) {
+			pack->gvc = PACKGVC_1_02 | PACKGVC_1_03 | PACKGVC_1_04;
+		} else if (!Q_stricmp(pack->pakBasename, "assets1")) {
+			pack->gvc = PACKGVC_1_02 | PACKGVC_1_03 | PACKGVC_1_04;
+		} else if (!Q_stricmp(pack->pakBasename, "assets2")) {
+			pack->gvc = PACKGVC_1_03 | PACKGVC_1_04;
+		} else if (!Q_stricmp(pack->pakBasename, "assets5")) {
+			pack->gvc = PACKGVC_1_04;
+		}
 	}
 
 	return pack;

--- a/src/qcommon/files.cpp
+++ b/src/qcommon/files.cpp
@@ -3332,7 +3332,7 @@ static void FS_Startup( const char *gameName ) {
 
 	assetsPathJKA = Sys_DefaultAssetsPathJKA();
 	fs_assetspathjka = Cvar_Get("fs_assetspathjka", assetsPathJKA ? assetsPathJKA : "", CVAR_INIT | CVAR_VM_NOWRITE);
-	fs_loadjka = Cvar_Get("fs_loadjka", "1", CVAR_ARCHIVE);
+	fs_loadjka = Cvar_Get("fs_loadjka", "1", CVAR_ARCHIVE | CVAR_LATCH);
 
 	if (!FS_AllPath_Base_FileExists("assets5.pk3")) {
 		// assets files found in none of the paths

--- a/src/qcommon/files.cpp
+++ b/src/qcommon/files.cpp
@@ -236,8 +236,8 @@ static	cvar_t		*fs_debug;
 static	cvar_t		*fs_homepath;
 static	cvar_t		*fs_basepath;
 static	cvar_t		*fs_assetspath;
-static	cvar_t		*fs_assetspathJKA;
-static	cvar_t		*fs_loadJKA;
+static	cvar_t		*fs_assetspathjka;
+static	cvar_t		*fs_loadjka;
 static	cvar_t		*fs_basegame;
 static	cvar_t		*fs_copyfiles;
 static	cvar_t		*fs_gamedirvar;
@@ -3331,8 +3331,8 @@ static void FS_Startup( const char *gameName ) {
 	fs_assetspath = Cvar_Get("fs_assetspath", assetsPath ? assetsPath : "", CVAR_INIT | CVAR_VM_NOWRITE);
 
 	assetsPathJKA = Sys_DefaultAssetsPathJKA();
-	fs_assetspathJKA = Cvar_Get("fs_assetspathJKA", assetsPathJKA ? assetsPathJKA : "", CVAR_INIT | CVAR_VM_NOWRITE);
-	fs_loadJKA = Cvar_Get("fs_loadJKA", "1", CVAR_ARCHIVE);
+	fs_assetspathjka = Cvar_Get("fs_assetspathjka", assetsPathJKA ? assetsPathJKA : "", CVAR_INIT | CVAR_VM_NOWRITE);
+	fs_loadjka = Cvar_Get("fs_loadjka", "1", CVAR_ARCHIVE);
 
 	if (!FS_AllPath_Base_FileExists("assets5.pk3")) {
 		// assets files found in none of the paths
@@ -3351,8 +3351,8 @@ static void FS_Startup( const char *gameName ) {
 	}
 
 	// Try to load JKA assets if a path has been specified
-	if (fs_assetspathJKA->string[0] && !fs_loadJKA->integer) {
-		FS_AddAssetsDirectoryJKA(fs_assetspathJKA->string, BASEGAME);
+	if (fs_assetspathjka->string[0] && !fs_loadjka->integer) {
+		FS_AddAssetsDirectoryJKA(fs_assetspathjka->string, BASEGAME);
 	}
 
 	// don't use the assetspath if assets files already found in fs_basepath or fs_homepath
@@ -3845,8 +3845,8 @@ void FS_InitFilesystem( void ) {
 	// has already been initialized
 	Com_StartupVariable( "fs_basepath" );
 	Com_StartupVariable( "fs_homepath" );
-	Com_StartupVariable( "fs_assetspathJKA" );
-	Com_StartupVariable( "fs_loadJKA" );
+	Com_StartupVariable( "fs_assetspathjka" );
+	Com_StartupVariable( "fs_loadjka" );
 #if !defined(PORTABLE)
 	Com_StartupVariable( "fs_assetspath" );
 #endif

--- a/src/qcommon/files.cpp
+++ b/src/qcommon/files.cpp
@@ -2941,7 +2941,7 @@ const char *get_filename(const char *path) {
 	return slash + 1;
 }
 
-static void FS_AddGameDirectory2( const char *path, const char *dir, qboolean assetsOnly, qboolean assetsJKA ) {
+static void FS_AddGameDirectory( const char *path, const char *dir, qboolean assetsJK2 = qfalse, qboolean assetsJKA = qfalse ) {
 	searchpath_t	*sp;
 	int				i;
 	searchpath_t	*search;
@@ -2970,7 +2970,7 @@ static void FS_AddGameDirectory2( const char *path, const char *dir, qboolean as
 	//
 	// add the directory to the search path
 	//
-	if (!assetsOnly && !assetsJKA) {
+	if (!assetsJK2 && !assetsJKA) {
 		search = (struct searchpath_s *)Z_Malloc(sizeof(searchpath_t), TAG_FILESYS, qtrue);
 		search->dir = (directory_t *)Z_Malloc(sizeof(*search->dir), TAG_FILESYS, qtrue);
 
@@ -2996,7 +2996,7 @@ static void FS_AddGameDirectory2( const char *path, const char *dir, qboolean as
 		pakfile = FS_BuildOSPath( path, dir, pakfiles[i] );
 		filename = get_filename(pakfile);
 
-		if (assetsOnly) {
+		if (assetsJK2) {
 			if (strcmp(filename, "assets0.pk3") && strcmp(filename, "assets1.pk3") &&
 				strcmp(filename, "assets2.pk3") && strcmp(filename, "assets5.pk3")) {
 				continue;
@@ -3056,8 +3056,12 @@ static void FS_AddGameDirectory2( const char *path, const char *dir, qboolean as
 	Sys_FreeFileList( pakfiles );
 }
 
-static void FS_AddGameDirectory( const char *path, const char *dir, qboolean assetsOnly ) {
-	FS_AddGameDirectory2( path, dir, assetsOnly, qfalse );
+static void FS_AddAssetsDirectoryJK2( const char *path, const char *dir ) {
+	FS_AddGameDirectory( path, dir, qtrue, qfalse );
+}
+
+static void FS_AddAssetsDirectoryJKA( const char *path, const char *dir ) {
+	FS_AddGameDirectory( path, dir, qfalse, qtrue );
 }
 
 /*
@@ -3346,41 +3350,41 @@ static void FS_Startup( const char *gameName ) {
 
 	// Try to load JKA assets if a path has been specified
 	if (fs_assetspathJKA->string[0] && !fs_noJKA->integer) {
-		FS_AddGameDirectory2(fs_assetspathJKA->string, BASEGAME, qfalse, qtrue);
+		FS_AddAssetsDirectoryJKA(fs_assetspathJKA->string, BASEGAME);
 	}
 
 	// don't use the assetspath if assets files already found in fs_basepath or fs_homepath
 	if (fs_assetspath->string[0] && !FS_BaseHome_Base_FileExists("assets5.pk3")) {
-		FS_AddGameDirectory(fs_assetspath->string, BASEGAME, qtrue);
+		FS_AddAssetsDirectoryJK2(fs_assetspath->string, BASEGAME);
 	}
 
 	// add search path elements in reverse priority order
 	if (fs_basepath->string[0]) {
-		FS_AddGameDirectory(fs_basepath->string, gameName, qfalse);
+		FS_AddGameDirectory(fs_basepath->string, gameName);
 	}
   // fs_homepath is somewhat particular to *nix systems, only add if relevant
   // NOTE: same filtering below for mods and basegame
 	if (fs_basepath->string[0] && Q_stricmp(fs_homepath->string,fs_basepath->string)) {
-		FS_AddGameDirectory(fs_homepath->string, gameName, qfalse);
+		FS_AddGameDirectory(fs_homepath->string, gameName);
 	}
 
 	// check for additional base game so mods can be based upon other mods
 	if ( fs_basegame->string[0] && !Q_stricmp( gameName, BASEGAME ) && Q_stricmp( fs_basegame->string, gameName ) ) {
 		if (fs_basepath->string[0]) {
-			FS_AddGameDirectory(fs_basepath->string, fs_basegame->string, qfalse);
+			FS_AddGameDirectory(fs_basepath->string, fs_basegame->string);
 		}
 		if (fs_homepath->string[0] && Q_stricmp(fs_homepath->string,fs_basepath->string)) {
-			FS_AddGameDirectory(fs_homepath->string, fs_basegame->string, qfalse);
+			FS_AddGameDirectory(fs_homepath->string, fs_basegame->string);
 		}
 	}
 
 	// check for additional game folder for mods
 	if ( fs_gamedirvar->string[0] && !Q_stricmp( gameName, BASEGAME ) && Q_stricmp( fs_gamedirvar->string, gameName ) ) {
 		if (fs_basepath->string[0]) {
-			FS_AddGameDirectory(fs_basepath->string, fs_gamedirvar->string, qfalse);
+			FS_AddGameDirectory(fs_basepath->string, fs_gamedirvar->string);
 		}
 		if (fs_homepath->string[0] && Q_stricmp(fs_homepath->string,fs_basepath->string)) {
-			FS_AddGameDirectory(fs_homepath->string, fs_gamedirvar->string, qfalse);
+			FS_AddGameDirectory(fs_homepath->string, fs_gamedirvar->string);
 		}
 	}
 
@@ -3388,10 +3392,10 @@ static void FS_Startup( const char *gameName ) {
 	if ( fs_forcegame->string[0] && Q_stricmp(fs_forcegame->string, fs_gamedir) ) {
 		if ( !fs_basegame->string[0] || Q_stricmp(fs_forcegame->string, fs_basegame->string) ) {
 			if (fs_basepath->string[0]) {
-				FS_AddGameDirectory(fs_basepath->string, fs_forcegame->string, qfalse);
+				FS_AddGameDirectory(fs_basepath->string, fs_forcegame->string);
 			}
 			if (fs_homepath->string[0] && Q_stricmp(fs_homepath->string,fs_basepath->string)) {
-				FS_AddGameDirectory(fs_homepath->string, fs_forcegame->string, qfalse);
+				FS_AddGameDirectory(fs_homepath->string, fs_forcegame->string);
 			}
 		}
 		Q_strncpyz( fs_gamedir, fs_forcegame->string, sizeof( fs_gamedir ) );

--- a/src/qcommon/files.cpp
+++ b/src/qcommon/files.cpp
@@ -237,7 +237,7 @@ static	cvar_t		*fs_homepath;
 static	cvar_t		*fs_basepath;
 static	cvar_t		*fs_assetspath;
 static	cvar_t		*fs_assetspathJKA;
-static	cvar_t		*fs_noJKA;
+static	cvar_t		*fs_loadJKA;
 static	cvar_t		*fs_basegame;
 static	cvar_t		*fs_copyfiles;
 static	cvar_t		*fs_gamedirvar;
@@ -3332,7 +3332,7 @@ static void FS_Startup( const char *gameName ) {
 
 	assetsPathJKA = Sys_DefaultAssetsPathJKA();
 	fs_assetspathJKA = Cvar_Get("fs_assetspathJKA", assetsPathJKA ? assetsPathJKA : "", CVAR_INIT | CVAR_VM_NOWRITE);
-	fs_noJKA = Cvar_Get("fs_noJKA", "0", CVAR_ARCHIVE);
+	fs_loadJKA = Cvar_Get("fs_loadJKA", "1", CVAR_ARCHIVE);
 
 	if (!FS_AllPath_Base_FileExists("assets5.pk3")) {
 		// assets files found in none of the paths
@@ -3351,7 +3351,7 @@ static void FS_Startup( const char *gameName ) {
 	}
 
 	// Try to load JKA assets if a path has been specified
-	if (fs_assetspathJKA->string[0] && !fs_noJKA->integer) {
+	if (fs_assetspathJKA->string[0] && !fs_loadJKA->integer) {
 		FS_AddAssetsDirectoryJKA(fs_assetspathJKA->string, BASEGAME);
 	}
 
@@ -3846,7 +3846,7 @@ void FS_InitFilesystem( void ) {
 	Com_StartupVariable( "fs_basepath" );
 	Com_StartupVariable( "fs_homepath" );
 	Com_StartupVariable( "fs_assetspathJKA" );
-	Com_StartupVariable( "fs_noJKA" );
+	Com_StartupVariable( "fs_loadJKA" );
 #if !defined(PORTABLE)
 	Com_StartupVariable( "fs_assetspath" );
 #endif

--- a/src/qcommon/files.cpp
+++ b/src/qcommon/files.cpp
@@ -1981,13 +1981,10 @@ static pack_t *FS_LoadZipFile( char *zipfile, const char *basename, qboolean ass
 		if ( assetsJKA ) {
 			// Ugly workaround: rename academy shader files to avoid collisions
 			if ( strLength > 7 && !Q_stricmp(filename_inzip + strLength - 7, ".shader") ) {
-				len += strLength + 5; // "_jka" + 1
-			} else {
-				len += strlen(filename_inzip) + 1;
+				len += 4; // "_jka"
 			}
-		} else {
-			len += strlen(filename_inzip) + 1;
 		}
+		len += strLength + 1;
 		unzGoToNextFile(uf);
 	}
 

--- a/src/qcommon/qcommon.h
+++ b/src/qcommon/qcommon.h
@@ -640,8 +640,8 @@ fileHandle_t FS_SV_FOpenFileWrite( const char *filename, module_t module = MODUL
 fileHandle_t FS_SV_FOpenFileAppend( const char *filename, module_t module = MODULE_MAIN );
 int		FS_SV_FOpenFileRead( const char *filename, fileHandle_t *fp, module_t module = MODULE_MAIN );
 void	FS_SV_Rename( const char *from, const char *to );
-int		FS_FOpenFileRead( const char *qpath, fileHandle_t *file, qboolean uniqueFILE, module_t module = MODULE_MAIN );
-int		FS_FOpenFileReadHash( const char *filename, fileHandle_t *file, qboolean uniqueFILE, unsigned long *filehash, module_t module = MODULE_MAIN );
+int		FS_FOpenFileRead( const char *qpath, fileHandle_t *file, qboolean uniqueFILE, module_t module = MODULE_MAIN, qboolean skipJKA = qfalse );
+int		FS_FOpenFileReadHash( const char *filename, fileHandle_t *file, qboolean uniqueFILE, unsigned long *filehash, module_t module = MODULE_MAIN, qboolean skipJKA = qfalse );
 // if uniqueFILE is true, then a new FILE will be fopened even if the file
 // is found in an already open pak file.  If uniqueFILE is false, you must call
 // FS_FCloseFile instead of fclose, otherwise the pak FILE would be improperly closed
@@ -667,6 +667,7 @@ int		FS_ReadFile( const char *qpath, void **buffer );
 // A 0 byte will always be appended at the end, so string ops are safe.
 // the buffer should be considered read-only, because it may be cached
 // for other uses.
+int		FS_ReadFileSkipJKA( const char *qpath, void **buffer );
 
 void	FS_ForceFlush( fileHandle_t f, module_t module = MODULE_MAIN );
 // forces flush on files we're writing to.

--- a/src/renderer/tr_image.cpp
+++ b/src/renderer/tr_image.cpp
@@ -22,8 +22,8 @@ using namespace std;
 #include <jpeglib.h>
 #include <png.h>
 
-static void LoadTGA( const char *name, byte **pic, int *width, int *height );
-static void LoadJPG( const char *name, byte **pic, int *width, int *height );
+static void LoadTGA( const char *name, byte **pic, int *width, int *height, qboolean skipJKA );
+static void LoadJPG( const char *name, byte **pic, int *width, int *height, qboolean skipJKA );
 
 static byte			 s_intensitytable[256];
 static unsigned char s_gammatable[256];
@@ -1205,7 +1205,7 @@ typedef struct
 //  returns false if found but had a format error, else true for either OK or not-found (there's a reason for this)
 //
 
-void LoadTGA ( const char *name, byte **pic, int *width, int *height)
+void LoadTGA ( const char *name, byte **pic, int *width, int *height, qboolean skipJKA)
 {
 	char sErrorString[1024];
 	bool bFormatErrors = false;
@@ -1226,7 +1226,8 @@ void LoadTGA ( const char *name, byte **pic, int *width, int *height)
 	// load the file
 	//
 	byte *pTempLoadedBuffer = 0;
-	ri.FS_ReadFile ( name, (void **)&pTempLoadedBuffer);
+	if ( skipJKA ) ri.FS_ReadFileSkipJKA( name, (void**)&pTempLoadedBuffer );
+	else           ri.FS_ReadFile ( name, (void **)&pTempLoadedBuffer);
 	if (!pTempLoadedBuffer) {
 		return;
 	}
@@ -1556,7 +1557,7 @@ static void R_JPGOutputMessage( j_common_ptr cinfo )
 	Com_Printf("%s\n", buffer);
 }
 
-void LoadJPG( const char *filename, unsigned char **pic, int *width, int *height ) {
+void LoadJPG( const char *filename, unsigned char **pic, int *width, int *height, qboolean skipJKA ) {
 	/* This struct contains the JPEG decompression parameters and pointers to
 	* working space (which is allocated as needed by the JPEG library).
 	*/
@@ -1591,7 +1592,9 @@ void LoadJPG( const char *filename, unsigned char **pic, int *width, int *height
 	* requires it in order to read binary files.
 	*/
 
-	int len = ri.FS_ReadFile ( filename, &fbuffer.v);
+	int len;
+	if ( skipJKA ) len = ri.FS_ReadFileSkipJKA ( filename, &fbuffer.v );
+	else           len = ri.FS_ReadFile ( filename, &fbuffer.v);
 	if (!fbuffer.b || len < 0) {
 		return;
 	}
@@ -2093,10 +2096,12 @@ void user_read_data(png_structp png_ptr, png_bytep data, png_size_t length) {
 }
 
 // Loads a PNG image from file.
-void LoadPNG(const char *filename, byte **data, int *width, int *height)
+void LoadPNG(const char *filename, byte **data, int *width, int *height, qboolean skipJKA)
 {
 	char *buf = NULL;
-	int len = ri.FS_ReadFile(filename, (void **)&buf);
+	int len;
+	if ( skipJKA ) len = ri.FS_ReadFileSkipJKA(filename, (void**)&buf);
+	else           len = ri.FS_ReadFile(filename, (void **)&buf);
 	if (len < 0 || buf == NULL)
 	{
 		return;
@@ -2125,23 +2130,47 @@ void R_LoadImage( const char *shortname, byte **pic, int *width, int *height )
 	*width = 0;
 	*height = 0;
 
+	// First try without JKA assets
 	COM_StripExtension(shortname,name,sizeof(name));
 	COM_DefaultExtension(name, sizeof(name), ".jpg");
-	LoadJPG( name, pic, width, height );
+	LoadJPG( name, pic, width, height, qtrue );
 	if (*pic) {
 		return;
 	}
 
 	COM_StripExtension(shortname,name,sizeof(name));
 	COM_DefaultExtension(name, sizeof(name), ".png");
-	LoadPNG( name, pic, width, height ); 			// try png first
+	LoadPNG( name, pic, width, height, qtrue ); 			// try png first
 	if (*pic){
 		return;
 	}
 
 	COM_StripExtension(shortname,name,sizeof(name));
 	COM_DefaultExtension(name, sizeof(name), ".tga");
-	LoadTGA( name, pic, width, height );            // try tga first
+	LoadTGA( name, pic, width, height, qtrue );            // try tga first
+	if (*pic){
+		return;
+	}
+
+
+	// Retry with JKA assets
+	COM_StripExtension(shortname,name,sizeof(name));
+	COM_DefaultExtension(name, sizeof(name), ".jpg");
+	LoadJPG( name, pic, width, height, qfalse );
+	if (*pic) {
+		return;
+	}
+
+	COM_StripExtension(shortname,name,sizeof(name));
+	COM_DefaultExtension(name, sizeof(name), ".png");
+	LoadPNG( name, pic, width, height, qfalse ); 			// try png first
+	if (*pic){
+		return;
+	}
+
+	COM_StripExtension(shortname,name,sizeof(name));
+	COM_DefaultExtension(name, sizeof(name), ".tga");
+	LoadTGA( name, pic, width, height, qfalse );            // try tga first
 	if (*pic){
 		return;
 	}

--- a/src/renderer/tr_public.h
+++ b/src/renderer/tr_public.h
@@ -150,6 +150,7 @@ typedef struct {
 	// NULL can be passed for buf to just determine existance
 	int		(*FS_FileIsInPAK)( const char *name, int *pCheckSum );
 	int		(*FS_ReadFile)( const char *name, void **buf );
+	int		(*FS_ReadFileSkipJKA)( const char *name, void **buf );
 	void	(*FS_FreeFile)( void *buf );
 	const char **	(*FS_ListFiles)( const char *name, const char *extension, int *numfilesfound );
 	void	(*FS_FreeFileList)( const char **filelist );

--- a/src/sys/sys_public.h
+++ b/src/sys/sys_public.h
@@ -116,6 +116,7 @@ int			Sys_PID( void );
 
 char *Sys_DefaultInstallPath(void);
 char *Sys_DefaultAssetsPath();
+char *Sys_DefaultAssetsPathJKA();
 char *Sys_DefaultHomePath(void);
 
 #ifdef MACOS_X

--- a/src/sys/sys_win32.cpp
+++ b/src/sys/sys_win32.cpp
@@ -80,6 +80,35 @@ char *Sys_DefaultAssetsPath() {
 #endif
 }
 
+// read the path from the registry on windows... apply the same workaround for the InstallPath as for jk2
+char *Sys_DefaultAssetsPathJKA() {
+#ifdef INSTALLED
+	HKEY hKey;
+	static char installPath[MAX_OSPATH];
+	DWORD installPathSize;
+
+	// force 32bit registry
+	if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, "SOFTWARE\\LucasArts\\Star Wars Jedi Knight Jedi Academy\\1.0",
+		0, KEY_WOW64_32KEY|KEY_QUERY_VALUE, &hKey) != ERROR_SUCCESS) {
+		return NULL;
+	}
+
+	installPathSize = sizeof(installPath);
+	if (RegQueryValueExA(hKey, "Install Path", NULL, NULL, (LPBYTE)installPath, &installPathSize) != ERROR_SUCCESS) {
+		if (RegQueryValueExA(hKey, "InstallPath", NULL, NULL, (LPBYTE)installPath, &installPathSize) != ERROR_SUCCESS) {
+			RegCloseKey(hKey);
+			return NULL;
+		}
+	}
+
+	RegCloseKey(hKey);
+	Q_strcat(installPath, sizeof(installPath), "\\GameData");
+	return installPath;
+#else
+	return NULL;
+#endif
+}
+
 char *Sys_DefaultInstallPath(void)
 {
 	return Sys_Cwd();


### PR DESCRIPTION
Add support for loading JKA assets:
 - cvar fs_assetsPathJKA; works similar to fs_assetsPath, but automatically tries to detect jka rather than jk2 (using registry keys on Windows and known paths on Mac)
 - new cvar fs_noJKA; disables loading of jka assets
 - jka assets are loaded before jk2 assets, thus jk2 files take precedence in case of conflicts
 - .shader files from jka assets are virtually renamed to .shader_jka and .shader_jka files are loaded with lower priority than .shader files
 - when trying to load an image the renderer tries to load all extensions without considering the jka assets and only includes jka assets if all extensions failed; this avoids cases of a higher priority extension images from the jka assets overriding jk2 images

Known (non-)issues:
  - as jka has intentionally been given a lower priority there can be cases where jka maps (or models) use jk2 versions of textures or shaders, making them look different than intended; this has already been the case before jka content was even available, making this irrelevant for this change
  - baseja supports entities that basejk doesn't support, as well as ICARUS scripting; jka maps may play different on jk2; adjusting this would be up to mods

To consider:
 - fs_noJKA defaults to "0", automatically enabling jka assets if available
 - fs_noJKA is currently not exposed on the menu; I think adding it to the menu would be a good idea, but we can do this after merging the branch so this can get some testing on development builds

Solves #80.