### PR TITLE
Improved Shader Remaps

### DIFF
--- a/src/client/cl_cgame.cpp
+++ b/src/client/cl_cgame.cpp
@@ -452,6 +452,10 @@ void CL_ConfigstringModified( void ) {
 		CL_SystemInfoChanged();
 	}
 
+	// Shader Remaps
+	if ( index == CS_MV_REMAPS ) {
+		CL_ShaderStateChanged();
+	}
 }
 
 

--- a/src/client/cl_cgame.cpp
+++ b/src/client/cl_cgame.cpp
@@ -453,7 +453,7 @@ void CL_ConfigstringModified( void ) {
 	}
 
 	// Shader Remaps
-	if ( index == CS_MV_REMAPS ) {
+	if ( index == cls.cs_remaps ) {
 		CL_ShaderStateChanged();
 	}
 }

--- a/src/client/cl_main.cpp
+++ b/src/client/cl_main.cpp
@@ -4090,6 +4090,17 @@ void CL_ShaderStateChanged( void ) {
 	// Skip prefix
 	curPos += 8;
 
+	// Example input (after skipping the "mvremap:" prefix above): "6console4clear929300;p;p;":
+	//  - "6" -> ascii 54 -> 54 - 47 = 7 -> the next 7 characters are the source shader name
+	//  - "console" -> source shader (7 characters)
+	//  - "4" -> ascii 52 -> 52 - 47 = 5 -> the next 5 characters are the destination shader name
+	//  - "clear" -> destination shader (5 characters)
+	//  - "9" -> ascii 57 -> 57 - 47 = 10 -> the next 10 characters are the options
+	//  - "29300;p;p;"
+	//    - "29300" -> timeOffset
+	//    - "p" -> lightmapMode
+	//    - "p" -> styleMode
+
 	// Parse configstring
 	while ( curPos < endPos )
 	{

--- a/src/client/cl_main.cpp
+++ b/src/client/cl_main.cpp
@@ -4060,13 +4060,19 @@ void CL_ShaderStateChanged( void ) {
 	shaderRemapLightmapType_t lightmapModeValue;
 	shaderRemapStyleType_t styleModeValue;
 
-	const char *curPos = cl.gameState.stringData + cl.gameState.stringOffsets[ CS_MV_REMAPS ];
-	const char *endPos = curPos + strlen( curPos );
+	const char *curPos;
+	const char *endPos;
 
 	int length;
 
-	// Check configstring for prefix to avoid misinterpreting configstrings from mods
-	if ( !curPos || !*curPos || strncmp(curPos, "mvremap:", 8) ) return;
+	// Make sure it's a valid configstring index
+	if ( cls.cs_remaps < CS_SYSTEMINFO || cls.cs_remaps >= MAX_CONFIGSTRINGS ) return;
+
+	// Clear any active remaps. We are going to reapply those that should stay below when parsing the string anyway.
+	re.RemoveAdvancedRemaps();
+
+	curPos = cl.gameState.stringData + cl.gameState.stringOffsets[ cls.cs_remaps ];
+	endPos = curPos + strlen( curPos );
 
 	// Handling of these is really ugly. I originally wanted to handle them like the base game/cgame modules do, but
 	// those are prone to injections. Summary of delimeter issues:
@@ -4087,10 +4093,7 @@ void CL_ShaderStateChanged( void ) {
 	//     it; this would allow for a size of up to 89, which is unlikely to be useful if MAX_QPATH ever gets increased
 	//  -> using 47 to 127
 
-	// Skip prefix
-	curPos += 8;
-
-	// Example input (after skipping the "mvremap:" prefix above): "6console4clear929300;p;p;":
+	// Example input: "6console4clear929300;p;p;":
 	//  - "6" -> ascii 54 -> 54 - 47 = 7 -> the next 7 characters are the source shader name
 	//  - "console" -> source shader (7 characters)
 	//  - "4" -> ascii 52 -> 52 - 47 = 5 -> the next 5 characters are the destination shader name

--- a/src/client/cl_main.cpp
+++ b/src/client/cl_main.cpp
@@ -4168,6 +4168,6 @@ void CL_ShaderStateChanged( void ) {
 		else styleModeValue = SHADERREMAP_STYLE_PRESERVE; // fallback to preserve
 
 		// Apply remap
-		re.RemapShaderAdvanced( originalShader, newShader, timeOffset, lightmapModeValue, styleModeValue );
+		re.RemapShaderAdvanced( originalShader, newShader, atoi(timeOffset), lightmapModeValue, styleModeValue );
 	}
 }

--- a/src/client/cl_main.cpp
+++ b/src/client/cl_main.cpp
@@ -4107,7 +4107,7 @@ void CL_ShaderStateChanged( void ) {
 		// Read original shader
 		length = *(curPos++);
 		length -= 47; // Length is increased by 47 to workaround netchan limits
-		if ( length < 0 )
+		if ( length < 1 )
 		{
 			Com_DPrintf( "CL_ShaderStateChanged: invalid length encoding for source shader\n" );
 			break;
@@ -4119,7 +4119,7 @@ void CL_ShaderStateChanged( void ) {
 		if ( curPos >= endPos ) break;
 		length = *(curPos++);
 		length -= 47; // Length is increased by 47 to workaround netchan limits
-		if ( length < 0 )
+		if ( length < 1 )
 		{
 			Com_DPrintf( "CL_ShaderStateChanged: invalid length encoding for destination shader\n" );
 			break;
@@ -4131,7 +4131,7 @@ void CL_ShaderStateChanged( void ) {
 		if ( curPos >= endPos ) break;
 		length = *(curPos++);
 		length -= 47; // Length is increased by 47 to workaround netchan limits
-		if ( length < 0 )
+		if ( length < 1 )
 		{
 			Com_DPrintf( "CL_ShaderStateChanged: invalid length encoding for settings\n" );
 			break;

--- a/src/client/cl_parse.cpp
+++ b/src/client/cl_parse.cpp
@@ -319,6 +319,7 @@ void CL_SystemInfoChanged( void ) {
 	char			key[BIG_INFO_KEY];
 	char			value[BIG_INFO_VALUE];
 	qboolean		gameSet;
+	int				old_cs_remaps = cls.cs_remaps;
 
 	systemInfo = cl.gameState.stringData + cl.gameState.stringOffsets[ CS_SYSTEMINFO ];
 	cl.serverId = atoi( Info_ValueForKey( systemInfo, "sv_serverid" ) );
@@ -326,6 +327,12 @@ void CL_SystemInfoChanged( void ) {
 	s = Info_ValueForKey( systemInfo, "sv_referencedPaks" );
 	t = Info_ValueForKey( systemInfo, "sv_referencedPakNames" );
 	FS_PureServerSetReferencedPaks( s, t );
+
+	cls.cs_remaps = atoi( Info_ValueForKey(systemInfo, "mv_cs_remaps") );
+	if ( cls.cs_remaps != old_cs_remaps ) {
+		// If the configstring changed remove any active advanced remaps
+		re.RemoveAdvancedRemaps();
+	}
 
 	// don't set any other vars when playing a demo
 	if ( clc.demoplaying ) {
@@ -484,6 +491,9 @@ void CL_ParseGamestate( msg_t *msg ) {
 
 	// parse serverId and other cvars
 	CL_SystemInfoChanged();
+
+	// Shader Remaps
+	CL_ShaderStateChanged();
 
 	// reinitialize the filesystem if the game directory has changed
 	if( FS_ConditionalRestart( clc.checksumFeed ) ) {

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -352,6 +352,8 @@ typedef struct {
 
 	int			fixes;
 	qboolean	submodelBypass;
+
+	int			cs_remaps;
 } clientStatic_t;
 
 #define	CON_TEXTSIZE	131072 // increased in jk2mv

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -501,6 +501,7 @@ int CL_ServerStatus( const char *serverAddress, char *serverStatusString, int ma
 
 void CL_GetVMGLConfig(vmglconfig_t *vmglconfig);
 int CL_ScaledMilliseconds(void);
+void CL_ShaderStateChanged( void );
 
 //
 // cl_input

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -42,6 +42,10 @@
 
 #define MAX_CLIENT_SCORE_SEND 20
 
+// mv_clflags - set by the client engine in the mv_clFlags userinfo cvar to inform the server about additional features
+#define MV_CLFLAG_SUBMODEL_BYPASS           (1)          // Indicates the client engine supports bypassing the MAX_SUBMODEL limit if the cgame module and the server support it, too.
+#define MV_CLFLAG_ADVANCED_REMAPS           (1 << 1)     // Indicates the client engine supports the new advanced shader remaps.
+
 //
 // config strings are a general means of communicating variable length strings
 // from the server to all connected clients.

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -100,6 +100,17 @@ Ghoul2 Insert End
 #error overflow: (CS_MAX) > MAX_CONFIGSTRINGS
 #endif
 
+
+// Using highest available configstring for new mv configstring, because mods should add own configstrings between
+// CS_STRING_PACKAGES and CS_MAX, making them come from the bottom.
+#define CS_MV_REMAPS            (MAX_CONFIGSTRINGS-1)
+#define CS_MV_MIN               (CS_MV_REMAPS)
+
+// Make sure CS_MAX and CS_MV_MIN don't overlap
+#if (CS_MAX) > (CS_MV_MIN)
+#error overflow: (CS_MAX) > (CS_MV_MIN)
+#endif
+
 typedef enum {
 	G2_MODELPART_HEAD = 10,
 	G2_MODELPART_WAIST,

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -100,17 +100,6 @@ Ghoul2 Insert End
 #error overflow: (CS_MAX) > MAX_CONFIGSTRINGS
 #endif
 
-
-// Using highest available configstring for new mv configstring, because mods should add own configstrings between
-// CS_STRING_PACKAGES and CS_MAX, making them come from the bottom.
-#define CS_MV_REMAPS            (MAX_CONFIGSTRINGS-1)
-#define CS_MV_MIN               (CS_MV_REMAPS)
-
-// Make sure CS_MAX and CS_MV_MIN don't overlap
-#if (CS_MAX) > (CS_MV_MIN)
-#error overflow: (CS_MAX) > (CS_MV_MIN)
-#endif
-
 typedef enum {
 	G2_MODELPART_HEAD = 10,
 	G2_MODELPART_WAIST,

--- a/src/renderer/tr_bsp.cpp
+++ b/src/renderer/tr_bsp.cpp
@@ -386,11 +386,6 @@ static shader_t *ShaderForShaderNum( int shaderNum, const int *lightmapNum, cons
 
 	shader = R_FindShader( dsh->shader, lightmapNum, styles, qtrue );
 
-	// if the shader had errors, just use default shader
-	if ( shader->defaultShader ) {
-		return tr.defaultShader;
-	}
-
 	return shader;
 }
 

--- a/src/renderer/tr_init.cpp
+++ b/src/renderer/tr_init.cpp
@@ -1523,6 +1523,7 @@ refexport_t *GetRefAPI ( int apiVersion, refimport_t *rimp ) {
 
 	re.RemapShader = R_RemapShader;
 	re.RemapShaderAdvanced = R_RemapShaderAdvanced;
+	re.RemoveAdvancedRemaps = R_RemoveAdvancedRemaps;
 	re.GetEntityToken = R_GetEntityToken;
 	re.inPVS = R_inPVS;
 

--- a/src/renderer/tr_init.cpp
+++ b/src/renderer/tr_init.cpp
@@ -1080,7 +1080,9 @@ void R_Register( void )
 	r_uiFullScreen = ri.Cvar_Get( "r_uifullscreen", "0", 0);
 	r_subdivisions = ri.Cvar_Get("r_subdivisions", "4", CVAR_ARCHIVE | CVAR_GLOBAL | CVAR_LATCH);
 	r_ignoreFastPath = ri.Cvar_Get("r_ignoreFastPath", "1", CVAR_ARCHIVE | CVAR_GLOBAL | CVAR_LATCH);
-	r_newRemaps = ri.Cvar_Get("r_newRemaps", "0", CVAR_ARCHIVE | CVAR_GLOBAL);
+	r_newRemaps = ri.Cvar_Get("r_newRemaps", "0", CVAR_CHEAT ); // Only used for testing. Classic remaps are supposed to remain fullbright,
+	                                                            // because that is how they have been used by maps and serverside mods for
+	                                                            // more than 20 years. Servers can set a configstring for "mvremap" now.
 
 	//
 	// temporary latched variables that can only change over a restart
@@ -1520,6 +1522,7 @@ refexport_t *GetRefAPI ( int apiVersion, refimport_t *rimp ) {
 	re.AnyLanguage_ReadCharFromString = AnyLanguage_ReadCharFromString;
 
 	re.RemapShader = R_RemapShader;
+	re.RemapShaderAdvanced = R_RemapShaderAdvanced;
 	re.GetEntityToken = R_GetEntityToken;
 	re.inPVS = R_inPVS;
 

--- a/src/renderer/tr_init.cpp
+++ b/src/renderer/tr_init.cpp
@@ -191,6 +191,7 @@ cvar_t *r_textureLODBias;
 cvar_t *r_saberGlow;
 cvar_t *r_environmentMapping;
 cvar_t *r_printMissingModels;
+cvar_t *r_newRemaps;
 
 #ifndef DEDICATED
 PFNGLACTIVETEXTUREARBPROC qglActiveTextureARB;
@@ -1079,6 +1080,7 @@ void R_Register( void )
 	r_uiFullScreen = ri.Cvar_Get( "r_uifullscreen", "0", 0);
 	r_subdivisions = ri.Cvar_Get("r_subdivisions", "4", CVAR_ARCHIVE | CVAR_GLOBAL | CVAR_LATCH);
 	r_ignoreFastPath = ri.Cvar_Get("r_ignoreFastPath", "1", CVAR_ARCHIVE | CVAR_GLOBAL | CVAR_LATCH);
+	r_newRemaps = ri.Cvar_Get("r_newRemaps", "0", CVAR_ARCHIVE | CVAR_GLOBAL);
 
 	//
 	// temporary latched variables that can only change over a restart

--- a/src/renderer/tr_local.h
+++ b/src/renderer/tr_local.h
@@ -1297,6 +1297,7 @@ extern	cvar_t *r_textureLODBias;
 extern	cvar_t *r_saberGlow;
 extern	cvar_t *r_environmentMapping;
 extern	cvar_t *r_printMissingModels;
+extern	cvar_t *r_newRemaps;
 //====================================================================
 
 float R_NoiseGet4f( float x, float y, float z, double t );
@@ -1459,6 +1460,7 @@ shader_t *R_FindShaderByName( const char *name );
 void		R_InitShaders( void );
 void		R_ShaderList_f( void );
 void	R_RemapShader(const char *oldShader, const char *newShader, const char *timeOffset);
+void R_RemapShaderWithLightmaps(const char *shaderName, const char *newShaderName, const char *timeOffset);
 
 /*
 ====================================================================

--- a/src/renderer/tr_local.h
+++ b/src/renderer/tr_local.h
@@ -492,6 +492,8 @@ Ghoul2 Insert End
 	// True if this shader has a stage with glow in it (just an optimization).
 	qboolean hasGlow;
 
+	qboolean advancedRemap;
+
 	struct shader_s *remappedShader;                  // current shader this one is remapped too
 
 	struct	shader_s	*next;
@@ -1460,7 +1462,7 @@ shader_t *R_FindShaderByName( const char *name );
 void		R_InitShaders( void );
 void		R_ShaderList_f( void );
 void	R_RemapShader(const char *oldShader, const char *newShader, const char *timeOffset);
-void R_RemapShaderWithLightmaps(const char *shaderName, const char *newShaderName, const char *timeOffset);
+void R_RemapShaderAdvanced(const char *shaderName, const char *newShaderName, const char *timeOffset, shaderRemapLightmapType_t lightmapMode, shaderRemapStyleType_t styleMode);
 
 /*
 ====================================================================

--- a/src/renderer/tr_local.h
+++ b/src/renderer/tr_local.h
@@ -1462,7 +1462,7 @@ shader_t *R_FindShaderByName( const char *name );
 void		R_InitShaders( void );
 void		R_ShaderList_f( void );
 void	R_RemapShader(const char *oldShader, const char *newShader, const char *timeOffset);
-void R_RemapShaderAdvanced(const char *shaderName, const char *newShaderName, const char *timeOffset, shaderRemapLightmapType_t lightmapMode, shaderRemapStyleType_t styleMode);
+void R_RemapShaderAdvanced(const char *shaderName, const char *newShaderName, int timeOffset, shaderRemapLightmapType_t lightmapMode, shaderRemapStyleType_t styleMode);
 
 /*
 ====================================================================

--- a/src/renderer/tr_local.h
+++ b/src/renderer/tr_local.h
@@ -492,9 +492,10 @@ Ghoul2 Insert End
 	// True if this shader has a stage with glow in it (just an optimization).
 	qboolean hasGlow;
 
-	qboolean advancedRemap;
+	qboolean isAdvancedRemap;
 
 	struct shader_s *remappedShader;                  // current shader this one is remapped too
+	struct shader_s *remappedShaderAdvanced;          // current shader from the advanced remaps this one is remapped to
 
 	struct	shader_s	*next;
 } shader_t;
@@ -1106,6 +1107,9 @@ typedef struct {
 	shader_t				*shaders[MAX_SHADERS];
 	shader_t				*sortedShaders[MAX_SHADERS];
 
+	int						numAdvancedRemapShaders;
+	shader_t				*advancedRemapShaders[MAX_SHADERS];
+
 	int						numSkins;
 	skin_t					*skins[MAX_SKINS];
 
@@ -1455,7 +1459,8 @@ qhandle_t		 RE_RegisterShader( const char *name );
 qhandle_t		 RE_RegisterShaderNoMip( const char *name );
 qhandle_t RE_RegisterShaderFromImage(const char *name, int *lightmapIndex, byte *styles, image_t *image, qboolean mipRawImage);
 
-shader_t	*R_FindShader( const char *name, const int *lightmapIndex, const byte *styles, qboolean mipRawImage );
+shader_t	*R_FindShader( const char *name, const int *lightmapIndex, const byte *styles, qboolean mipRawImage, qboolean isAdvancedRemap = qfalse );
+shader_t	*R_FindAdvancedRemapShader( const char *name, const int *lightmapIndex, const byte *styles, qboolean mipRawImage );
 shader_t	*R_GetShaderByHandle( qhandle_t hShader );
 // shader_t	*R_GetShaderByState( int index, int *cycleTime );
 shader_t *R_FindShaderByName( const char *name );

--- a/src/renderer/tr_local.h
+++ b/src/renderer/tr_local.h
@@ -1463,6 +1463,7 @@ void		R_InitShaders( void );
 void		R_ShaderList_f( void );
 void	R_RemapShader(const char *oldShader, const char *newShader, const char *timeOffset);
 void R_RemapShaderAdvanced(const char *shaderName, const char *newShaderName, int timeOffset, shaderRemapLightmapType_t lightmapMode, shaderRemapStyleType_t styleMode);
+void R_RemoveAdvancedRemaps( void );
 
 /*
 ====================================================================

--- a/src/renderer/tr_public.h
+++ b/src/renderer/tr_public.h
@@ -106,7 +106,7 @@ typedef struct {
 	unsigned int (*AnyLanguage_ReadCharFromString)( const char *psText, int *piAdvanceCount, qboolean *pbIsTrailingPunctuation/* = NULL*/ );
 
 	void	(*RemapShader)(const char *oldShader, const char *newShader, const char *offsetTime);
-	void	(*RemapShaderAdvanced)(const char *oldShader, const char *newShader, const char *offsetTime, shaderRemapLightmapType_t lightmapMode, shaderRemapStyleType_t styleMode);
+	void	(*RemapShaderAdvanced)(const char *oldShader, const char *newShader, int offsetTime, shaderRemapLightmapType_t lightmapMode, shaderRemapStyleType_t styleMode);
 	qboolean (*GetEntityToken)( char *buffer, int size );
 	qboolean (*inPVS)( const vec3_t p1, const vec3_t p2 );
 

--- a/src/renderer/tr_public.h
+++ b/src/renderer/tr_public.h
@@ -107,6 +107,7 @@ typedef struct {
 
 	void	(*RemapShader)(const char *oldShader, const char *newShader, const char *offsetTime);
 	void	(*RemapShaderAdvanced)(const char *oldShader, const char *newShader, int offsetTime, shaderRemapLightmapType_t lightmapMode, shaderRemapStyleType_t styleMode);
+	void	(*RemoveAdvancedRemaps)(void);
 	qboolean (*GetEntityToken)( char *buffer, int size );
 	qboolean (*inPVS)( const vec3_t p1, const vec3_t p2 );
 

--- a/src/renderer/tr_public.h
+++ b/src/renderer/tr_public.h
@@ -5,6 +5,22 @@
 
 #define	REF_API_VERSION		8
 
+
+typedef enum
+{
+	SHADERREMAP_LIGHTMAP_PRESERVE,
+	SHADERREMAP_LIGHTMAP_NONE,
+	SHADERREMAP_LIGHTMAP_FULLBRIGHT,
+	SHADERREMAP_LIGHTMAP_VERTEX,
+	SHADERREMAP_LIGHTMAP_2D,
+} shaderRemapLightmapType_t;
+
+typedef enum
+{
+	SHADERREMAP_STYLE_PRESERVE,
+	SHADERREMAP_STYLE_DEFAULT,
+} shaderRemapStyleType_t;
+
 //
 // these are the functions exported by the refresh module
 //
@@ -90,6 +106,7 @@ typedef struct {
 	unsigned int (*AnyLanguage_ReadCharFromString)( const char *psText, int *piAdvanceCount, qboolean *pbIsTrailingPunctuation/* = NULL*/ );
 
 	void	(*RemapShader)(const char *oldShader, const char *newShader, const char *offsetTime);
+	void	(*RemapShaderAdvanced)(const char *oldShader, const char *newShader, const char *offsetTime, shaderRemapLightmapType_t lightmapMode, shaderRemapStyleType_t styleMode);
 	qboolean (*GetEntityToken)( char *buffer, int size );
 	qboolean (*inPVS)( const vec3_t p1, const vec3_t p2 );
 

--- a/src/renderer/tr_shade.cpp
+++ b/src/renderer/tr_shade.cpp
@@ -322,6 +322,7 @@ to overflow.
 void RB_BeginSurface( shader_t *shader, int fogNum ) {
 
 	shader_t *state = (shader->remappedShaderAdvanced ? shader->remappedShaderAdvanced : (shader->remappedShader ? shader->remappedShader : shader));
+	if ( state->defaultShader ) state = tr.defaultShader;
 
 	tess.numIndexes = 0;
 	tess.numVertexes = 0;

--- a/src/renderer/tr_shade.cpp
+++ b/src/renderer/tr_shade.cpp
@@ -321,7 +321,7 @@ to overflow.
 */
 void RB_BeginSurface( shader_t *shader, int fogNum ) {
 
-	shader_t *state = (shader->remappedShader) ? shader->remappedShader : shader;
+	shader_t *state = (shader->remappedShaderAdvanced ? shader->remappedShaderAdvanced : (shader->remappedShader ? shader->remappedShader : shader));
 
 	tess.numIndexes = 0;
 	tess.numVertexes = 0;

--- a/src/renderer/tr_shader.cpp
+++ b/src/renderer/tr_shader.cpp
@@ -206,7 +206,7 @@ void R_RemapShader(const char *shaderName, const char *newShaderName, const char
 	qhandle_t	h;
 
 	if ( r_newRemaps->integer ) {
-		R_RemapShaderAdvanced( shaderName, newShaderName, timeOffset, SHADERREMAP_LIGHTMAP_PRESERVE, SHADERREMAP_STYLE_PRESERVE );
+		R_RemapShaderAdvanced( shaderName, newShaderName, (int)(atof(timeOffset)*1000), SHADERREMAP_LIGHTMAP_PRESERVE, SHADERREMAP_STYLE_PRESERVE );
 		return;
 	}
 
@@ -254,11 +254,10 @@ void R_RemapShader(const char *shaderName, const char *newShaderName, const char
 	}
 }
 
-void R_RemapShaderAdvanced(const char *shaderName, const char *newShaderName, const char *timeOffset, shaderRemapLightmapType_t lightmapMode, shaderRemapStyleType_t styleMode) {
+void R_RemapShaderAdvanced(const char *shaderName, const char *newShaderName, int timeOffset, shaderRemapLightmapType_t lightmapMode, shaderRemapStyleType_t styleMode) {
 	char		strippedName[MAX_QPATH];
 	int			hash;
 	shader_t	*sh, *sh2 = NULL;
-	float		timeOffsetFloat = timeOffset ? atof( timeOffset ) : 0.0f;
 	qhandle_t	h;
 	int			failed = 0;
 	const int	*lightmapIndex = NULL;
@@ -315,7 +314,7 @@ void R_RemapShaderAdvanced(const char *shaderName, const char *newShaderName, co
 				failed++;
 				continue;
 			}
-			if ( timeOffset ) sh2->timeOffset = timeOffsetFloat;
+			if ( timeOffset ) sh2->timeOffset = timeOffset * 0.001;
 
 			if (sh != sh2) {
 				sh->remappedShader = sh2;

--- a/src/renderer/tr_shader.cpp
+++ b/src/renderer/tr_shader.cpp
@@ -328,6 +328,21 @@ void R_RemapShaderAdvanced(const char *shaderName, const char *newShaderName, in
 	if ( failed ) ri.Printf( PRINT_WARNING, "WARNING: R_RemapShaderAdvanced: new shader %s not found (x%i)\n", newShaderName, failed );
 }
 
+void R_RemoveAdvancedRemaps( void ) {
+	int i;
+	shader_t *cur;
+	for ( i = 0; i < (int)ARRAY_LEN(hashTable); i++ ) {
+		cur = hashTable[i];
+		while ( cur ) {
+			if ( cur->advancedRemap ) {
+				cur->remappedShader = NULL;
+				cur->advancedRemap = qfalse;
+			}
+			cur = cur->next;
+		}
+	}
+}
+
 /*
 ===============
 ParseVector

--- a/src/server/sv_init.cpp
+++ b/src/server/sv_init.cpp
@@ -842,6 +842,12 @@ void SV_Init (void) {
 	Cvar_Get ("sv_referencedPaks", "", CVAR_SYSTEMINFO | CVAR_ROM );
 	Cvar_Get ("sv_referencedPakNames", "", CVAR_SYSTEMINFO | CVAR_ROM );
 
+	// The mv_cs_remaps systeminfo cvar can be used by game module mods to
+	// announce the index of the configstring used for mvremaps. Registering the
+	// cvar here is not actually required. We just register it here to ensure
+	// the right flags are set on it.
+	Cvar_Get ("mv_cs_remaps", "", CVAR_SYSTEMINFO | CVAR_ROM | CVAR_INTERNAL );
+
 	// server vars
 	sv_rconPassword = Cvar_Get ("rconPassword", "", CVAR_TEMP );
 	sv_privatePassword = Cvar_Get ("sv_privatePassword", "", CVAR_TEMP );


### PR DESCRIPTION
The vanilla shader remaps don't handle lightmaps properly, leading to various issues:
 - remapping a texture/shader to itself causes all instances to use the lightmap of the first instance, resulting in incorrect spots ("cow" look); this prevents the server from undoing some shader remaps
 - remapping a texture/shader to a texture/shader that wasn't loaded causes the new shader to use the internal `lightmapNone`, making the new shader either completly dark or fullbright

In most situations these issues are undesired, but maps have utilized these effects to light up and darken areas by remapping shaders. For that reason the default behavior of the shader remaps should not be altered.

This branch introduces a new function `R_RemapShaderAdvanced` which support additional arguments to specify the desired mode of shader remapping (preserve, fullbright, none, vertex, 2d) and indirectly exposes it to servers via configstring 1399.

Screenshots to compare:
 - Fullbright / Vanilla: [![Fullbright](https://dark-clan.servegame.com/pictures/jk2mv/remaps/shot0000.jpg)](https://dark-clan.servegame.com/pictures/jk2mv/remaps/shot0000.jpg)
 - Preserve: [![Preserve](https://dark-clan.servegame.com/pictures/jk2mv/remaps/shot0001.jpg)](https://dark-clan.servegame.com/pictures/jk2mv/remaps/shot0001.jpg)