### PR TITLE
Fix bounds check in S_StartSound

### DIFF
--- a/src/client/snd_dma.cpp
+++ b/src/client/snd_dma.cpp
@@ -1268,7 +1268,7 @@ void S_StartSound(const vec3_t origin, int entityNum, int entchannel, sfxHandle_
 		return;
 	}
 
-	if ( !origin && ( entityNum < 0 || entityNum > MAX_GENTITIES ) ) {
+	if ( !origin && ( entityNum < 0 || entityNum >= MAX_GENTITIES ) ) {
 		Com_Error( ERR_DROP, "S_StartSound: bad entitynum %i", entityNum );
 	}
 


### PR DESCRIPTION
I found it while trying to debug https://github.com/mvdevs/mvsdk/pull/14