### PR TITLE
r_overBrightBitsJKA: Overbright settings only for maps recognized as JKA map

### DIFF
--- a/CVARS.rst
+++ b/CVARS.rst
@@ -316,6 +316,16 @@ Client-Side
 
 ..
 
+:Name: r_overBrightBitsJKA
+:Values: Integer >= 0
+:Default: "0"
+:Description:
+   Overbright on maps recognized as made for Jedi Academy. These are
+   maps loaded from basejka or fs_assetspathjka directories and maps
+   with ojka_ prefix or "compatible jka" string in mv.info file
+
+..
+
 :Name: r_saberGlow
 :Values: "0", "1"
 :Default: "1"

--- a/src/client/cl_cgame.cpp
+++ b/src/client/cl_cgame.cpp
@@ -1358,6 +1358,10 @@ void CL_InitCGame( void ) {
 	mapname = Info_ValueForKey( info, "mapname" );
 	Com_sprintf( cl.mapname, sizeof( cl.mapname ), "maps/%s.bsp", mapname );
 
+	mapversion_t mapversion = CM_MapVersion(cl.mapname);
+	MV_SetCurrentMapVersion(mapversion);
+	Com_Printf("mapversion set to %s\n", MV_GetMapVersionString(mapversion));
+
 	// load the dll or bytecode
 	if ( cl_connectedToPureServer != 0 ) {
 		// if sv_pure is set we only allow qvms to be loaded

--- a/src/client/cl_main.cpp
+++ b/src/client/cl_main.cpp
@@ -750,6 +750,7 @@ void CL_FlushMemory( qboolean disconnecting ) {
 
 	if (disconnecting && !com_sv_running->integer) {
 		MV_SetCurrentGameversion(VERSION_UNDEF);
+		MV_SetCurrentMapVersion(MAPVERSION_UNDEF);
 
 		FS_PureServerSetReferencedPaks("", "");
 		// change checksum feed so that next FS_ConditionalRestart()

--- a/src/client/cl_scrn.cpp
+++ b/src/client/cl_scrn.cpp
@@ -405,7 +405,8 @@ void MV_DrawConnectingInfo( void )
 	Com_sprintf(txtbuf, sizeof(txtbuf), "^1[ ^7JK2MV " JK2MV_VERSION " " PLATFORM_STRING " ^1]");
 	SCR_DrawStringExt(320 - SCR_Strlen(txtbuf) * 4, yPos + (line * 0), 8, txtbuf, g_color_table[7], qfalse);
 
-	Com_sprintf(txtbuf, sizeof(txtbuf), "Game-Version^1: ^71.%02d", (int)MV_GetCurrentGameversion());
+	const char *mapverstr = MV_GetMapVersionString(MV_GetCurrentMapVersion());
+	Com_sprintf(txtbuf, sizeof(txtbuf), "Game-Version^1: ^71.%02d Map-Version^1: ^7%s", (int)MV_GetCurrentGameversion(), mapverstr);
 	SCR_DrawStringExt((int)(320 - SCR_Strlen(txtbuf) * 3.5), yPos + (line * 1), 7, txtbuf, g_color_table[7], qfalse);
 }
 

--- a/src/qcommon/cm_load.cpp
+++ b/src/qcommon/cm_load.cpp
@@ -61,6 +61,16 @@ void	CM_FloodAreaConnections (void);
 ===============================================================================
 */
 
+mapversion_t CM_MapVersion(const char *name) {
+	if (FS_ReadFileSkipJKA(name, NULL) != -1) {
+		return MAPVERSION_JK2;
+	} else if (FS_ReadFile(name, NULL) != -1) {
+		return MAPVERSION_JKA;
+	} else {
+		return MAPVERSION_UNDEF;
+	}
+}
+
 /*
 =================
 CMod_LoadShaders

--- a/src/qcommon/cm_public.h
+++ b/src/qcommon/cm_public.h
@@ -41,6 +41,8 @@ qboolean	CM_AreasConnected( int area1, int area2 );
 
 int			CM_WriteAreaBits( byte *buffer, int area );
 
+mapversion_t	CM_MapVersion(const char *name);
+
 // cm_tag.c
 int			CM_LerpTag( orientation_t *tag,  clipHandle_t model, int startFrame, int endFrame,
 					 float frac, const char *tagName );

--- a/src/qcommon/common.cpp
+++ b/src/qcommon/common.cpp
@@ -2453,6 +2453,7 @@ void Com_Init( char *commandLine ) {
 	// multiprotocol support
 	// startup will be UNDEFINED
 	MV_SetCurrentGameversion(VERSION_UNDEF);
+	MV_SetCurrentMapVersion(MAPVERSION_UNDEF);
 
 	// bk001129 - do this before anything else decides to push events
 	Com_InitPushEvent();
@@ -3049,6 +3050,27 @@ mvprotocol_t MV_GetCurrentProtocol() {
 		default:
 			return PROTOCOL_UNDEF;
 	}
+}
+
+static mapversion_t mv_mapversion = MAPVERSION_UNDEF;
+
+void MV_SetCurrentMapVersion(mapversion_t version) {
+	mv_mapversion = version;
+}
+
+mapversion_t MV_GetCurrentMapVersion() {
+	return mv_mapversion;
+}
+
+const char *MV_GetMapVersionString(mapversion_t mapversion) {
+	switch(mapversion) {
+	case MAPVERSION_UNDEF: return "Unknown"; break;
+	case MAPVERSION_JK2:   return "JK2";     break;
+	case MAPVERSION_JKA:   return "JKA";     break;
+	}
+
+	assert(0);
+	return "";
 }
 
 // for auto-complete (copied from OpenJK)

--- a/src/qcommon/qcommon.h
+++ b/src/qcommon/qcommon.h
@@ -1056,9 +1056,18 @@ extern huffman_t clientHuffTables;
 #define	CL_ENCODE_START		12
 #define CL_DECODE_START		4
 
+typedef enum {
+	MAPVERSION_UNDEF,
+	MAPVERSION_JK2,
+	MAPVERSION_JKA
+} mapversion_t;
+
 void MV_SetCurrentGameversion(mvversion_t version);
 mvversion_t MV_GetCurrentGameversion();
 mvprotocol_t MV_GetCurrentProtocol();
+void MV_SetCurrentMapVersion(mapversion_t version);
+mapversion_t MV_GetCurrentMapVersion();
+const char *MV_GetMapVersionString(mapversion_t mapversion);
 
 #define	MAX_SUBMODELS			256
 

--- a/src/renderer/tr_image.cpp
+++ b/src/renderer/tr_image.cpp
@@ -2645,7 +2645,11 @@ void R_SetColorMappings( void ) {
 	int		shift;
 
 	// setup the overbright lighting
-	tr.overbrightBits = r_overBrightBits->integer;
+	if (tr.mapversion == MAPVERSION_JKA) {
+		tr.overbrightBits = r_overBrightBitsJKA->integer;
+	} else {
+		tr.overbrightBits = r_overBrightBits->integer;
+	}
 
 	if (r_gammamethod->integer == GAMMA_NONE)
 	{

--- a/src/renderer/tr_init.cpp
+++ b/src/renderer/tr_init.cpp
@@ -145,6 +145,7 @@ cvar_t	*r_lodCurveError;
 cvar_t	*r_customaspect;
 
 cvar_t	*r_overBrightBits;
+cvar_t	*r_overBrightBitsJKA;
 
 cvar_t	*r_debugSurface;
 cvar_t	*r_simpleMipMaps;
@@ -1074,6 +1075,7 @@ void R_Register( void )
 	r_texturebits = ri.Cvar_Get("r_texturebits", "0", CVAR_ARCHIVE | CVAR_GLOBAL | CVAR_LATCH);
 	r_texturebitslm = ri.Cvar_Get("r_texturebitslm", "0", CVAR_ARCHIVE | CVAR_GLOBAL | CVAR_LATCH);
 	r_overBrightBits = ri.Cvar_Get("r_overBrightBits", "1", CVAR_ARCHIVE | CVAR_GLOBAL | CVAR_LATCH);
+	r_overBrightBitsJKA = ri.Cvar_Get("r_overBrightBitsJKA", "0", CVAR_ARCHIVE | CVAR_GLOBAL | CVAR_LATCH);
 	r_intensity = ri.Cvar_Get("r_intensity", "1", CVAR_ARCHIVE | CVAR_GLOBAL | CVAR_LATCH);
 	r_aspectratio = ri.Cvar_Get("r_aspectratio", "-1", CVAR_ARCHIVE | CVAR_GLOBAL | CVAR_LATCH); // screen resolutions
 	r_customaspect = ri.Cvar_Get("r_customaspect", "1", CVAR_ARCHIVE | CVAR_GLOBAL | CVAR_LATCH);
@@ -1230,7 +1232,7 @@ Ghoul2 Insert End
 R_Init
 ===============
 */
-void R_Init( void ) {
+void R_Init( mapversion_t mapversion ) {
 	int i;
 	byte *ptr;
 
@@ -1244,6 +1246,8 @@ void R_Init( void ) {
 #endif
 
 //	Swap_Init();
+
+	tr.mapversion = mapversion;
 
 #ifndef DEDICATED
 	Com_Memset( tess.constantColor255, 255, sizeof( tess.constantColor255 ) );

--- a/src/renderer/tr_local.h
+++ b/src/renderer/tr_local.h
@@ -1135,6 +1135,8 @@ typedef struct {
 	// gamma correction
 	GLuint gammaVertexShader, gammaPixelShader;
 	GLuint gammaLUTImage;
+
+	mapversion_t mapversion;
 } trGlobals_t;
 
 
@@ -1277,6 +1279,7 @@ extern	cvar_t	*r_skipBackEnd;
 extern	cvar_t	*r_ignoreGLErrors;
 
 extern	cvar_t	*r_overBrightBits;
+extern	cvar_t	*r_overBrightBitsJKA;
 
 extern	cvar_t	*r_debugSurface;
 extern	cvar_t	*r_simpleMipMaps;
@@ -1419,7 +1422,7 @@ qboolean	R_GetEntityToken( char *buffer, int size );
 
 model_t		*R_AllocModel( void );
 
-void		R_Init( void );
+void		R_Init( mapversion_t mapversion );
 void R_LoadImage( const char *name, byte **pic, int *width, int *height );
 image_t		*R_FindImageFile( const char *name, qboolean mipmap, qboolean allowPicmip, qboolean allowTC, int glWrapClampMode );
 image_t		*R_FindImageFileNew( const char *name, const upload_t *upload, int glWrapClampMode );

--- a/src/renderer/tr_model.cpp
+++ b/src/renderer/tr_model.cpp
@@ -1489,7 +1489,7 @@ static qboolean R_LoadMD4( model_t *mod, void *buffer, const char *mod_name, qbo
 */
 void RE_BeginRegistration( glconfig_t *glconfigOut ) {
 
-	R_Init();
+	R_Init(MV_GetCurrentMapVersion());
 
 	*glconfigOut = glConfig;
 

--- a/src/server/sv_init.cpp
+++ b/src/server/sv_init.cpp
@@ -470,6 +470,10 @@ Ghoul2 Insert End
 	// clear the whole hunk because we're (re)loading the server
 	Hunk_Clear();
 
+	mapversion_t mapversion = CM_MapVersion(va("maps/%s.bsp", server));
+	MV_SetCurrentMapVersion(mapversion);
+	Com_Printf("mapversion set to %s\n", MV_GetMapVersionString(mapversion));
+
 /*
 Ghoul2 Insert Start
 */


### PR DESCRIPTION
These are:
* maps loaded from pk3 in basejka or fs_assetspathjka directories
* maps loaded from pk3 with ojka_ prefix
* maps loaded from pk3 with "compatible jka" string in mv.info file

There is a function in place now (MV_GetCurrentMapVersion()) to change engine behaviour depending if map is considered jk2 map or jka - even if the rules how we detect this change.

Some ideas:
* Blacklisting some file extensions from jka assets
* Giving priority to jka assets when map is jka
* Special renderer behaviour to make some missing jka features work
* Special mvapi and module behaviour to make some missing jka features work